### PR TITLE
Reintegrate changes from July - Nov 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ Desktop.ini
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 .vscode/
+.vs/

--- a/doc/index.md
+++ b/doc/index.md
@@ -99,7 +99,7 @@ Generate a sequence on the fly with a range comprehension and initialize a vecto
     using namespace ranges;
     std::vector<int> vi =
         view::for_each(view::ints(1,10), [](int i){
-            return yield_from(view::repeat(i,i));
+            return yield_from(view::repeat_n(i,i));
         });
     // vi == {1,2,2,3,3,3,4,4,4,4,5,5,5,5,5,...}
 ~~~~~~~

--- a/doc/index.md
+++ b/doc/index.md
@@ -209,7 +209,7 @@ Below in roughly 2 dozen lines of code is the `transform` view, which takes one 
     public:
         transform_view() = default;
         transform_view(Rng && rng, Fun fun)
-          : view_adaptor_t<transform_view>{std::forward<Rng>(rng)}
+          : transform_view::view_adaptor{std::forward<Rng>(rng)}
           , fun_(std::move(fun))
         {}
     };

--- a/doc/index.md
+++ b/doc/index.md
@@ -149,7 +149,7 @@ Range v3 provides a utility for easily creating your own range types, called `vi
     {
         friend range_access;
         char const * sz_;
-        char const & current() const { return *sz_; }
+        char const & get() const { return *sz_; }
         bool done() const { return *sz_ == '\0'; }
         void next() { ++sz_; }
     public:
@@ -199,7 +199,7 @@ Below in roughly 2 dozen lines of code is the `transform` view, which takes one 
             adaptor() = default;
             adaptor(semiregular_t<Fun> const &fun) : fun_(fun) {}
             // Here is where we apply Fun to the elements:
-            auto current(range_iterator_t<Rng> it) const -> decltype(fun_(*it))
+            auto get(range_iterator_t<Rng> it) const -> decltype(fun_(*it))
             {
                 return fun_(*it);
             }
@@ -221,7 +221,7 @@ Below in roughly 2 dozen lines of code is the `transform` view, which takes one 
     }
 ~~~~~~~
 
-Range transformation is achieved by defining a nested `adaptor` class that handles the transformation, and then defining `begin_adaptor` and `end_adaptor` members that return adaptors for the begin iterator and the end sentinel, respectively. The `adaptor` class has a `current` member that performs the transformation. It is passed an iterator to the current element. Other members are available for customization: `equal`, `next`, `prev`, `advance`, and `distance_to`; but the transform adaptor accepts the defaults defined in `adaptor_base`.
+Range transformation is achieved by defining a nested `adaptor` class that handles the transformation, and then defining `begin_adaptor` and `end_adaptor` members that return adaptors for the begin iterator and the end sentinel, respectively. The `adaptor` class has a `get` member that performs the transformation. It is passed an iterator to the current element. Other members are available for customization: `equal`, `next`, `prev`, `advance`, and `distance_to`; but the transform adaptor accepts the defaults defined in `adaptor_base`.
 
 With `transform_view`, we can print out the first 20 squares:
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,6 +4,10 @@ add_test(test.example.comprehensions, comprehensions)
 add_executable(fibonacci fibonacci.cpp)
 add_test(test.example.fibonacci, fibonacci)
 
+#add_executable(n_queens n_queens.cpp)
+#add_test(test.example.n_queens, n_queens)
+#set_target_properties(n_queens PROPERTIES COMPILE_FLAGS "-std=gnu++14")
+
 # Guarded with a variable because:
 #  (a) The calendar example causes gcc to puke, and
 #  (b) It requires a fix for Boost.Range(!!!) that is

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -173,11 +173,7 @@ class chunk_view : public view_adaptor<chunk_view<Rng>, Rng> {
 public:
     chunk_view() = default;
     chunk_view(Rng rng, std::size_t n)
-#ifdef RANGES_WORKAROUND_MSVC_207134
       : chunk_view::view_adaptor(std::move(rng))
-#else
-      : view_adaptor_t<chunk_view>(std::move(rng))
-#endif
       , n_(n)
     {}
 };

--- a/example/calendar.cpp
+++ b/example/calendar.cpp
@@ -191,13 +191,14 @@ public:
     adaptor(std::size_t n, range_sentinel_t<Rng> end)
       : n_(n), end_(end)
     {}
-    auto current(range_iterator_t<Rng> it) const {
+    auto get(range_iterator_t<Rng> it) const {
         return view::take(make_range(std::move(it), end_), n_);
     }
     void next(range_iterator_t<Rng> &it) {
         ranges::advance(it, n_, end_);
     }
     void prev() = delete;
+    void distance_to() = delete;
 };
 
 // In:  Range<T>
@@ -233,7 +234,7 @@ struct interleave_view<Rngs>::cursor  {
     std::size_t n_;
     std::vector<range_value_t<Rngs>> *rngs_;
     std::vector<range_iterator_t<range_value_t<Rngs>>> its_;
-    decltype(auto) current() const {
+    decltype(auto) get() const {
         return *its_[n_];
     }
     void next() {

--- a/include/meta/meta_fwd.hpp
+++ b/include/meta/meta_fwd.hpp
@@ -15,6 +15,8 @@
 #ifndef META_FWD_HPP
 #define META_FWD_HPP
 
+#include <utility>
+
 #ifndef META_DISABLE_DEPRECATED_WARNINGS
 #ifdef __cpp_attribute_deprecated
 #define META_DEPRECATED(MSG) [[deprecated(MSG)]]
@@ -35,8 +37,12 @@ namespace meta
 {
     inline namespace v1
     {
+#if defined(__cpp_lib_integer_sequence) || (defined(_MSC_VER) &&  _MSC_VER >= 1900)
+        using std::integer_sequence;
+#else
         template <typename T, T...>
         struct integer_sequence;
+#endif
 
         template <typename... Ts>
         struct list;

--- a/include/range/v3/action/insert.hpp
+++ b/include/range/v3/action/insert.hpp
@@ -101,12 +101,6 @@ namespace ranges
             /// \cond
             namespace detail
             {
-                template<typename C, typename I, typename S>
-                using ReserveConcept =
-                    meta::fast_and<
-                        RandomAccessReservable<C>,
-                        SizedIteratorRange<I, S>>;
-
                 template<typename Cont, typename P, typename I, typename S,
                     typename C = common_iterator<I, S>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
@@ -123,11 +117,11 @@ namespace ranges
                 template<typename Cont, typename P, typename I, typename S,
                     typename C = common_iterator<I, S>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>::value && Iterator<P>::value && IteratorRange<I, S>::value &&
-                                      ReserveConcept<Cont, I, S>::value)>
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>::value && Iterator<P>::value && SizedIteratorRange<I, S>::value &&
+                                      RandomAccessReservable<Cont>::value)>
 #else
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && IteratorRange<I, S>() &&
-                                      ReserveConcept<Cont, I, S>())>
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<P>() && SizedIteratorRange<I, S>() &&
+                                      RandomAccessReservable<Cont>())>
 #endif
                 auto insert_impl(Cont && cont, P p, I i, S j, std::true_type) ->
                     decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{i}, C{j}))
@@ -154,11 +148,11 @@ namespace ranges
                 template<typename Cont, typename I, typename Rng,
                     typename C = range_common_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>::value && Iterator<I>::value && Range<Rng>::value &&
-                                      ReserveConcept<Cont, range_iterator_t<Rng>, range_sentinel_t<Rng>>::value)>
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>::value && Iterator<I>::value && SizedRange<Rng>::value &&
+                                      RandomAccessReservable<Cont>::value)>
 #else
-                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && Range<Rng>() &&
-                                      ReserveConcept<Cont, range_iterator_t<Rng>, range_sentinel_t<Rng>>())>
+                    CONCEPT_REQUIRES_(LvalueContainerLike<Cont>() && Iterator<I>() && SizedRange<Rng>() &&
+                                      RandomAccessReservable<Cont>())>
 #endif
                 auto insert_impl(Cont && cont, I p, Rng && rng, std::true_type) ->
                     decltype(unwrap_reference(cont).insert(begin(unwrap_reference(cont)), C{begin(rng)}, C{end(rng)}))
@@ -181,7 +175,7 @@ namespace ranges
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 detail::insert_impl(std::forward<Cont>(cont), std::move(p), std::move(i), std::move(j),
-                                    detail::ReserveConcept<Cont, I, S>())
+                                    meta::fast_and<RandomAccessReservable<Cont>, SizedIteratorRange<I, S>>{})
             )
 
             template<typename Cont, typename I, typename Rng,
@@ -195,7 +189,7 @@ namespace ranges
             RANGES_DECLTYPE_AUTO_RETURN
             (
                 detail::insert_impl(std::forward<Cont>(cont), std::move(p), std::forward<Rng>(rng),
-                                    detail::ReserveConcept<Cont, range_iterator_t<Rng>, range_sentinel_t<Rng>>())
+                                    meta::fast_and<RandomAccessReservable<Cont>, SizedRange<Rng>>{})
             )
 
             struct insert_fn

--- a/include/range/v3/action/remove_if.hpp
+++ b/include/range/v3/action/remove_if.hpp
@@ -93,10 +93,10 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, I>(),
                         "The object on which action::remove_if operates must allow element "
                         "removal.");
-                    CONCEPT_ASSERT_MSG(Projectable<I, P>(),
+                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
-                        "reference type, and rvalue reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<C, Project<I, P>>(),
+                        "reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectCallablePredicate<C, Projected<I, P>>(),
                         "The predicate passed to action::remove_if must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/action/sort.hpp
+++ b/include/range/v3/action/sort.hpp
@@ -86,10 +86,10 @@ namespace ranges
                         "The object on which action::sort operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(Projectable<I, P>(),
+                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
-                        "reference type, and rvalue reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, Project<I, P>>(),
+                        "reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, Projected<I, P>>(),
                         "The comparator passed to action::sort must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/action/stable_sort.hpp
+++ b/include/range/v3/action/stable_sort.hpp
@@ -86,10 +86,10 @@ namespace ranges
                         "The object on which action::stable_sort operates must be a model of the "
                         "ForwardRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(Projectable<I, P>(),
+                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
-                        "reference type, and rvalue reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, Project<I, P>>(),
+                        "reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, Projected<I, P>>(),
                         "The comparator passed to action::stable_sort must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/action/transform.hpp
+++ b/include/range/v3/action/transform.hpp
@@ -86,10 +86,10 @@ namespace ranges
                         "The object on which action::transform operates must be a model of the "
                         "InputRange concept.");
                     using I = range_iterator_t<Rng>;
-                    CONCEPT_ASSERT_MSG(Projectable<I, P>(),
+                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
-                        "reference type, and rvalue reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallable<F, Project<I, P>>(),
+                        "reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectCallable<F, Projected<I, P>>(),
                         "The function argument to action::transform must be callable with "
                         "the result of the projection argument, or with objects of the range's "
                         "common reference type if no projection is specified.");

--- a/include/range/v3/action/unique.hpp
+++ b/include/range/v3/action/unique.hpp
@@ -93,10 +93,10 @@ namespace ranges
                     CONCEPT_ASSERT_MSG(ErasableRange<Rng, I, S>(),
                         "The object on which action::unique operates must allow element "
                         "removal.");
-                    CONCEPT_ASSERT_MSG(Projectable<I, P>(),
+                    CONCEPT_ASSERT_MSG(IndirectCallable<P, I>(),
                         "The projection function must accept objects of the iterator's value type, "
-                        "reference type, and rvalue reference type.");
-                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, Project<I, P>>(),
+                        "reference type, and common reference type.");
+                    CONCEPT_ASSERT_MSG(IndirectCallableRelation<C, Projected<I, P>>(),
                         "The comparator passed to action::unique must accept objects returned "
                         "by the projection function, or of the range's value type if no projection "
                         "is specified.");

--- a/include/range/v3/algorithm/adjacent_find.hpp
+++ b/include/range/v3/algorithm/adjacent_find.hpp
@@ -38,10 +38,10 @@ namespace ranges
             template<typename I, typename S, typename C = equal_to, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             I
             operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
@@ -62,10 +62,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             range_safe_iterator_t<Rng>
             operator()(Rng &&rng, C pred = C{}, P proj = P{}) const

--- a/include/range/v3/algorithm/all_of.hpp
+++ b/include/range/v3/algorithm/all_of.hpp
@@ -34,10 +34,10 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallablePredicate<F, Project<I, P> >::value)>
+                    IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallablePredicate<F, Project<I, P> >())>
+                    IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
@@ -53,9 +53,9 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<F, Project<I, P> >::value)>
+                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, Project<I, P> >())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const

--- a/include/range/v3/algorithm/any_of.hpp
+++ b/include/range/v3/algorithm/any_of.hpp
@@ -35,10 +35,10 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallablePredicate<F, Project<I, P> >::value)>
+                    IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallablePredicate<F, Project<I, P> >())>
+                    IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
@@ -54,9 +54,9 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<F, Project<I, P> >::value)>
+                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, Project<I, P> >())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const

--- a/include/range/v3/algorithm/copy_if.hpp
+++ b/include/range/v3/algorithm/copy_if.hpp
@@ -37,11 +37,11 @@ namespace ranges
             template<typename I, typename S, typename O, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    WeaklyIncrementable<O>::value && IndirectCallablePredicate<F, Project<I, P> >::value &&
+                    WeaklyIncrementable<O>::value && IndirectCallablePredicate<F, Projected<I, P> >::value &&
                     IndirectlyCopyable<I, O>::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    WeaklyIncrementable<O>() && IndirectCallablePredicate<F, Project<I, P> >() &&
+                    WeaklyIncrementable<O>() && IndirectCallablePredicate<F, Projected<I, P> >() &&
                     IndirectlyCopyable<I, O>())>
 #endif
             tagged_pair<tag::in(I), tag::out(O)>
@@ -65,10 +65,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value && WeaklyIncrementable<O>::value &&
-                    IndirectCallablePredicate<F, Project<I, P> >::value && IndirectlyCopyable<I, O>::value)>
+                    IndirectCallablePredicate<F, Projected<I, P> >::value && IndirectlyCopyable<I, O>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() && WeaklyIncrementable<O>() &&
-                    IndirectCallablePredicate<F, Project<I, P> >() && IndirectlyCopyable<I, O>())>
+                    IndirectCallablePredicate<F, Projected<I, P> >() && IndirectlyCopyable<I, O>())>
 #endif
             tagged_pair<tag::in(range_safe_iterator_t<Rng>), tag::out(O)>
             operator()(Rng &&rng, O out, F pred, P proj = P{}) const

--- a/include/range/v3/algorithm/count.hpp
+++ b/include/range/v3/algorithm/count.hpp
@@ -34,10 +34,10 @@ namespace ranges
             template<typename I, typename S, typename V, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>::value)>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>())>
 #endif
             iterator_difference_t<I>
             operator()(I begin, S end, V const & val, P proj_ = P{}) const
@@ -54,10 +54,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>::value)>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>())>
 #endif
             iterator_difference_t<I>
             operator()(Rng &&rng, V const & val, P proj = P{}) const

--- a/include/range/v3/algorithm/count_if.hpp
+++ b/include/range/v3/algorithm/count_if.hpp
@@ -34,10 +34,10 @@ namespace ranges
             template<typename I, typename S, typename R, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallablePredicate<R, Project<I, P> >::value)>
+                    IndirectCallablePredicate<R, Projected<I, P> >::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallablePredicate<R, Project<I, P> >())>
+                    IndirectCallablePredicate<R, Projected<I, P> >())>
 #endif
             iterator_difference_t<I>
             operator()(I begin, S end, R pred_, P proj_ = P{}) const
@@ -54,9 +54,9 @@ namespace ranges
             template<typename Rng, typename R, typename P = ident,
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<R, Project<I, P> >::value)>
+                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<R, Projected<I, P> >::value)>
 #else
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<R, Project<I, P> >())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<R, Projected<I, P> >())>
 #endif
             iterator_difference_t<I>
             operator()(Rng &&rng, R pred, P proj = P{}) const

--- a/include/range/v3/algorithm/find.hpp
+++ b/include/range/v3/algorithm/find.hpp
@@ -43,10 +43,10 @@ namespace ranges
             template<typename I, typename S, typename V, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>::value)>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>())>
 #endif
             I operator()(I begin, S end, V const &val, P proj_ = P{}) const
             {
@@ -62,10 +62,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>::value)>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallableRelation<equal_to, Project<I, P>, V const *>())>
+                    IndirectCallableRelation<equal_to, Projected<I, P>, V const *>())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, V const &val, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/find_end.hpp
+++ b/include/range/v3/algorithm/find_end.hpp
@@ -181,11 +181,11 @@ namespace ranges
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I1>::value && IteratorRange<I1, S1>::value &&
                     ForwardIterator<I2>::value && IteratorRange<I2, S2>::value &&
-                    IndirectCallableRelation<R, Project<I1, P>, I2>::value)>
+                    IndirectCallableRelation<R, Projected<I1, P>, I2>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I1>() && IteratorRange<I1, S1>() &&
                     ForwardIterator<I2>() && IteratorRange<I2, S2>() &&
-                    IndirectCallableRelation<R, Project<I1, P>, I2>())>
+                    IndirectCallableRelation<R, Projected<I1, P>, I2>())>
 #endif
             I1 operator()(I1 begin1, S1 end1, I2 begin2, S2 end2, R pred = R{}, P proj = P{}) const
             {
@@ -202,10 +202,10 @@ namespace ranges
                 typename I2 = range_iterator_t<Rng2>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng1>::value && ForwardRange<Rng2>::value &&
-                    IndirectCallableRelation<R, Project<I1, P>, I2>::value)>
+                    IndirectCallableRelation<R, Projected<I1, P>, I2>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng1>() && ForwardRange<Rng2>() &&
-                    IndirectCallableRelation<R, Project<I1, P>, I2>())>
+                    IndirectCallableRelation<R, Projected<I1, P>, I2>())>
 #endif
             range_safe_iterator_t<Rng1> operator()(Rng1 &&rng1, Rng2 &&rng2, R pred = R{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/find_if.hpp
+++ b/include/range/v3/algorithm/find_if.hpp
@@ -45,10 +45,10 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallablePredicate<F, Project<I, P> >::value)>
+                    IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallablePredicate<F, Project<I, P> >())>
+                    IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             I operator()(I begin, S end, F pred_, P proj_ = P{}) const
             {
@@ -65,10 +65,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value &&
-                    IndirectCallablePredicate<F, Project<I, P>>::value)>
+                    IndirectCallablePredicate<F, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallablePredicate<F, Project<I, P>>())>
+                    IndirectCallablePredicate<F, Projected<I, P>>())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/find_if_not.hpp
+++ b/include/range/v3/algorithm/find_if_not.hpp
@@ -45,10 +45,10 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallablePredicate<F, Project<I, P> >::value)>
+                    IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallablePredicate<F, Project<I, P> >())>
+                    IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             I operator()(I begin, S end, F pred_, P proj_ = P{}) const
             {
@@ -65,10 +65,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value &&
-                    IndirectCallablePredicate<F, Project<I, P> >::value)>
+                    IndirectCallablePredicate<F, Projected<I, P> >::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() &&
-                    IndirectCallablePredicate<F, Project<I, P> >())>
+                    IndirectCallablePredicate<F, Projected<I, P> >())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F pred, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/for_each.hpp
+++ b/include/range/v3/algorithm/for_each.hpp
@@ -33,10 +33,10 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallable<F, Project<I, P>>::value)>
+                    IndirectCallable<F, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallable<F, Project<I, P>>())>
+                    IndirectCallable<F, Projected<I, P>>())>
 #endif
             I operator()(I begin, S end, F fun_, P proj_ = P{}) const
             {
@@ -52,9 +52,9 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallable<F, Project<I, P>>::value)>
+                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallable<F, Projected<I, P>>::value)>
 #else
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallable<F, Project<I, P>>())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallable<F, Projected<I, P>>())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, F fun, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/heap_algorithm.hpp
+++ b/include/range/v3/algorithm/heap_algorithm.hpp
@@ -42,7 +42,7 @@ namespace ranges
         template<typename I, typename C = ordered_less, typename P = ident>
         using IsHeapable = meta::fast_and<
             RandomAccessIterator<I>,
-            IndirectCallableRelation<C, Project<I, P>>>;
+            IndirectCallableRelation<C, Projected<I, P>>>;
 
         /// \cond
         namespace detail

--- a/include/range/v3/algorithm/is_partitioned.hpp
+++ b/include/range/v3/algorithm/is_partitioned.hpp
@@ -39,7 +39,7 @@ namespace ranges
         template<typename I, typename C, typename P = ident>
         using IsPartitionedable = meta::fast_and<
             InputIterator<I>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/is_sorted.hpp
+++ b/include/range/v3/algorithm/is_sorted.hpp
@@ -42,10 +42,10 @@ namespace ranges
             template<typename I, typename S, typename R = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<R, Project<I, P>>::value)>
+                    IndirectCallableRelation<R, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
-                       IndirectCallableRelation<R, Project<I, P>>())>
+                    IndirectCallableRelation<R, Projected<I, P>>())>
 #endif
             bool operator()(I begin, S end, R rel = R{}, P proj_ = P{}) const
             {
@@ -57,10 +57,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng>::value &&
-                    IndirectCallableRelation<R, Project<I, P>>::value)>
+                    IndirectCallableRelation<R, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<R, Project<I, P>>())>
+                    IndirectCallableRelation<R, Projected<I, P>>())>
 #endif
             bool operator()(Rng &&rng, R rel = R{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/is_sorted_until.hpp
+++ b/include/range/v3/algorithm/is_sorted_until.hpp
@@ -44,10 +44,10 @@ namespace ranges
             template<typename I, typename S, typename R = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<R, Project<I, P>>::value)>
+                    IndirectCallableRelation<R, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<R, Project<I, P>>())>
+                    IndirectCallableRelation<R, Projected<I, P>>())>
 #endif
             I operator()(I begin, S end, R pred_ = R{}, P proj_ = P{}) const
             {
@@ -70,10 +70,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng>::value &&
-                    IndirectCallableRelation<R, Project<I, P>>::value)>
+                    IndirectCallableRelation<R, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<R, Project<I, P>>())>
+                    IndirectCallableRelation<R, Projected<I, P>>())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, R pred = R{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/max.hpp
+++ b/include/range/v3/algorithm/max.hpp
@@ -44,10 +44,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>, typename V = iterator_value_t<I>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value && Copyable<V>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() && Copyable<V>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             RANGES_CXX14_CONSTEXPR V operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
             {
@@ -69,10 +69,10 @@ namespace ranges
             template<typename T, typename C = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, Project<const T *, P>>::value)>
+                    IndirectCallableRelation<C, Projected<const T *, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, Project<const T *, P>>())>
+                    IndirectCallableRelation<C, Projected<const T *, P>>())>
 #endif
             constexpr const T& operator()(const T &a, const T &b, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/max_element.hpp
+++ b/include/range/v3/algorithm/max_element.hpp
@@ -34,10 +34,10 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
@@ -54,10 +54,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/min.hpp
+++ b/include/range/v3/algorithm/min.hpp
@@ -44,10 +44,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>, typename V = iterator_value_t<I>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value && Copyable<V>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() && Copyable<V>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             RANGES_CXX14_CONSTEXPR V operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
             {
@@ -69,10 +69,10 @@ namespace ranges
             template<typename T, typename C = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, Project<const T *, P>>::value)>
+                    IndirectCallableRelation<C, Projected<const T *, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, Project<const T *, P>>())>
+                    IndirectCallableRelation<C, Projected<const T *, P>>())>
 #endif
             constexpr const T& operator()(const T &a, const T &b, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/min_element.hpp
+++ b/include/range/v3/algorithm/min_element.hpp
@@ -34,10 +34,10 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             I operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
             {
@@ -54,10 +54,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             range_safe_iterator_t<Rng> operator()(Rng &&rng, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/minmax.hpp
+++ b/include/range/v3/algorithm/minmax.hpp
@@ -48,10 +48,10 @@ namespace ranges
                 typename R = tagged_pair<tag::min(V), tag::max(V)>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputRange<Rng>::value && Copyable<V>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(InputRange<Rng>() && Copyable<V>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             RANGES_CXX14_CONSTEXPR R
             operator()(Rng &&rng, C pred_ = C{}, P proj_ = P{}) const
@@ -105,10 +105,10 @@ namespace ranges
             template<typename T, typename C = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, Project<const T *, P>>::value)>
+                    IndirectCallableRelation<C, Projected<const T *, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(
-                    IndirectCallableRelation<C, Project<const T *, P>>())>
+                    IndirectCallableRelation<C, Projected<const T *, P>>())>
 #endif
             constexpr const T& operator()(const T &a, const T &b, C pred = C{}, P proj = P{}) const
             {

--- a/include/range/v3/algorithm/minmax_element.hpp
+++ b/include/range/v3/algorithm/minmax_element.hpp
@@ -39,10 +39,10 @@ namespace ranges
             template<typename I, typename S, typename C = ordered_less, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             tagged_pair<tag::min(I), tag::max(I)>
             operator()(I begin, S end, C pred_ = C{}, P proj_ = P{}) const
@@ -92,10 +92,10 @@ namespace ranges
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(ForwardRange<Rng>::value &&
-                    IndirectCallableRelation<C, Project<I, P>>::value)>
+                    IndirectCallableRelation<C, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(ForwardRange<Rng>() &&
-                    IndirectCallableRelation<C, Project<I, P>>())>
+                    IndirectCallableRelation<C, Projected<I, P>>())>
 #endif
             meta::if_<std::is_lvalue_reference<Rng>,
                 tagged_pair<tag::min(I), tag::max(I)>,

--- a/include/range/v3/algorithm/mismatch.hpp
+++ b/include/range/v3/algorithm/mismatch.hpp
@@ -39,7 +39,7 @@ namespace ranges
         using Mismatchable1 = meta::fast_and<
             InputIterator<I1>,
             WeakInputIterator<I2>,
-            IndirectCallablePredicate<C, Project<I1, P1>, Project<I2, P2>>>;
+            IndirectCallablePredicate<C, Projected<I1, P1>, Projected<I2, P2>>>;
 
         /// \ingroup group-concepts
         template<typename I1, typename I2, typename C = equal_to, typename P1 = ident,
@@ -47,7 +47,7 @@ namespace ranges
         using Mismatchable2 = meta::fast_and<
             InputIterator<I1>,
             InputIterator<I2>,
-            IndirectCallablePredicate<C, Project<I1, P1>, Project<I2, P2>>>;
+            IndirectCallablePredicate<C, Projected<I1, P1>, Projected<I2, P2>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/none_of.hpp
+++ b/include/range/v3/algorithm/none_of.hpp
@@ -35,10 +35,10 @@ namespace ranges
             template<typename I, typename S, typename F, typename P = ident,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                 CONCEPT_REQUIRES_(InputIterator<I>::value && IteratorRange<I, S>::value &&
-                    IndirectCallablePredicate<F, Project<I, P>>::value)>
+                    IndirectCallablePredicate<F, Projected<I, P>>::value)>
 #else
                 CONCEPT_REQUIRES_(InputIterator<I>() && IteratorRange<I, S>() &&
-                    IndirectCallablePredicate<F, Project<I, P>>())>
+                    IndirectCallablePredicate<F, Projected<I, P>>())>
 #endif
             bool
             operator()(I first, S last, F pred, P proj = P{}) const
@@ -54,9 +54,9 @@ namespace ranges
             template<typename Rng, typename F, typename P = ident,
                 typename I = range_iterator_t<Rng>,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<F, Project<I, P>>::value)>
+                CONCEPT_REQUIRES_(InputRange<Rng>::value && IndirectCallablePredicate<F, Projected<I, P>>::value)>
 #else
-                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, Project<I, P>>())>
+                CONCEPT_REQUIRES_(InputRange<Rng>() && IndirectCallablePredicate<F, Projected<I, P>>())>
 #endif
             bool
             operator()(Rng &&rng, F pred, P proj = P{}) const

--- a/include/range/v3/algorithm/partial_sort_copy.hpp
+++ b/include/range/v3/algorithm/partial_sort_copy.hpp
@@ -36,7 +36,7 @@ namespace ranges
             InputIterator<I>,
             RandomAccessIterator<O>,
             IndirectlyCopyable<I, O>,
-            IndirectCallableRelation<C, Project<I, PI>, Project<O, PO>>,
+            IndirectCallableRelation<C, Projected<I, PI>, Projected<O, PO>>,
             Sortable<O, C, PO>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/partition.hpp
+++ b/include/range/v3/algorithm/partition.hpp
@@ -41,7 +41,7 @@ namespace ranges
         using Partitionable = meta::fast_and<
             ForwardIterator<I>,
             Permutable<I>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/partition_copy.hpp
+++ b/include/range/v3/algorithm/partition_copy.hpp
@@ -40,7 +40,7 @@ namespace ranges
             WeaklyIncrementable<O1>,
             IndirectlyCopyable<I, O0>,
             IndirectlyCopyable<I, O1>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/partition_move.hpp
+++ b/include/range/v3/algorithm/partition_move.hpp
@@ -40,7 +40,7 @@ namespace ranges
             WeaklyIncrementable<O1>,
             IndirectlyMovable<I, O0>,
             IndirectlyMovable<I, O1>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/partition_point.hpp
+++ b/include/range/v3/algorithm/partition_point.hpp
@@ -43,7 +43,7 @@ namespace ranges
             typename X = concepts::Callable::result_t<P, V>>
         using PartitionPointable = meta::fast_and<
             ForwardIterator<I>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -82,7 +82,7 @@ namespace ranges
                             goto next_iter;
                     {
                         // Count number of *i in [f2, l2)
-                        iterator_difference_t<I1> c2 = 0;
+                        iterator_difference_t<I2> c2 = 0;
                         for(I2 j = begin2; j != end2; ++j)
                             if(pred(proj1(*i), proj2(*j)))
                                 ++c2;
@@ -136,7 +136,7 @@ namespace ranges
                             goto next_iter;
                     {
                         // Count number of *i in [f2, l2)
-                        iterator_difference_t<I1> c2 = 0;
+                        iterator_difference_t<I2> c2 = 0;
                         for(I2 j = begin2; j != end2; ++j)
                             if(pred(proj1(*i), proj2(*j)))
                                 ++c2;

--- a/include/range/v3/algorithm/permutation.hpp
+++ b/include/range/v3/algorithm/permutation.hpp
@@ -60,7 +60,7 @@ namespace ranges
                 auto &&pred = as_function(pred_);
                 auto &&proj1 = as_function(proj1_);
                 auto &&proj2 = as_function(proj2_);
-                // shorten sequences as much as possible by lopping of any equal parts
+                // shorten sequences as much as possible by lopping off any equal parts
                 for(; begin1 != end1 && begin2 != end2; ++begin1, ++begin2)
                     if(!pred(proj1(*begin1), proj2(*begin2)))
                         goto not_done;
@@ -115,7 +115,7 @@ namespace ranges
                 auto &&pred = as_function(pred_);
                 auto &&proj1 = as_function(proj1_);
                 auto &&proj2 = as_function(proj2_);
-                // shorten sequences as much as possible by lopping of any equal parts
+                // shorten sequences as much as possible by lopping off any equal parts
                 for(; begin1 != end1; ++begin1, ++begin2)
                     if(!pred(proj1(*begin1), proj2(*begin2)))
                         goto not_done;

--- a/include/range/v3/algorithm/remove.hpp
+++ b/include/range/v3/algorithm/remove.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename T, typename P = ident>
         using Removable = meta::fast_and<
             ForwardIterator<I>,
-            IndirectCallableRelation<equal_to, Project<I, P>, T const *>,
+            IndirectCallableRelation<equal_to, Projected<I, P>, T const *>,
             Permutable<I>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/remove_copy.hpp
+++ b/include/range/v3/algorithm/remove_copy.hpp
@@ -34,7 +34,7 @@ namespace ranges
         using RemoveCopyable = meta::fast_and<
             InputIterator<I>,
             WeaklyIncrementable<O>,
-            IndirectCallableRelation<equal_to, Project<I, P>, T const *>,
+            IndirectCallableRelation<equal_to, Projected<I, P>, T const *>,
             IndirectlyCopyable<I, O>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/remove_copy_if.hpp
+++ b/include/range/v3/algorithm/remove_copy_if.hpp
@@ -34,7 +34,7 @@ namespace ranges
         using RemoveCopyableIf = meta::fast_and<
             InputIterator<I>,
             WeaklyIncrementable<O>,
-            IndirectCallablePredicate<C, Project<I, P>>,
+            IndirectCallablePredicate<C, Projected<I, P>>,
             IndirectlyCopyable<I, O>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/remove_if.hpp
+++ b/include/range/v3/algorithm/remove_if.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename C, typename P = ident>
         using RemovableIf = meta::fast_and<
             ForwardIterator<I>,
-            IndirectCallablePredicate<C, Project<I, P>>,
+            IndirectCallablePredicate<C, Projected<I, P>>,
             Permutable<I>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/replace.hpp
+++ b/include/range/v3/algorithm/replace.hpp
@@ -31,7 +31,7 @@ namespace ranges
         template<typename I, typename T0, typename T1, typename P = ident>
         using Replaceable = meta::fast_and<
             InputIterator<I>,
-            IndirectCallableRelation<equal_to, Project<I, P>, T0 const *>,
+            IndirectCallableRelation<equal_to, Projected<I, P>, T0 const *>,
             Writable<I, T1>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/replace_copy.hpp
+++ b/include/range/v3/algorithm/replace_copy.hpp
@@ -35,7 +35,7 @@ namespace ranges
             InputIterator<I>,
             WeakOutputIterator<O, T1>,
             IndirectlyCopyable<I, O>,
-            IndirectCallableRelation<equal_to, Project<I, P>, T0 const *>>;
+            IndirectCallableRelation<equal_to, Projected<I, P>, T0 const *>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/replace_copy_if.hpp
+++ b/include/range/v3/algorithm/replace_copy_if.hpp
@@ -35,7 +35,7 @@ namespace ranges
             InputIterator<I>,
             WeakOutputIterator<O, T>,
             IndirectlyCopyable<I, O>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/replace_if.hpp
+++ b/include/range/v3/algorithm/replace_if.hpp
@@ -31,7 +31,7 @@ namespace ranges
         template<typename I, typename C, typename T, typename P = ident>
         using ReplaceIfable = meta::fast_and<
             InputIterator<I>,
-            IndirectCallablePredicate<C, Project<I, P>>,
+            IndirectCallablePredicate<C, Projected<I, P>>,
             Writable<I, T>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/search.hpp
+++ b/include/range/v3/algorithm/search.hpp
@@ -51,48 +51,6 @@ namespace ranges
         struct search_fn
         {
         private:
-            template<typename I1, typename D1, typename I2, typename S2, typename D2,
-                typename C, typename P1, typename P2,
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(RandomAccessIterator<I1>::value)>
-#else
-                CONCEPT_REQUIRES_(RandomAccessIterator<I1>())>
-#endif
-            static I1 sized_impl(I1 const begin1_, I1 end1, D1 d1, I2 begin2, S2 end2, D2 d2,
-                C &pred, P1 &proj1, P2 &proj2)
-            {
-                if(d1 < d2)
-                    return end1;
-                auto begin1 = uncounted(begin1_);
-                auto const s = uncounted(end1 - (d2 - 1)); // Start of pattern match can't go beyond here
-                while(true)
-                {
-                    // Find begin element in sequence 1 that matches *begin2, with a mininum of loop checks
-                    while(true)
-                    {
-                        if(begin1 == s)  // return the end if we've run out of room
-                            return end1;
-                        if(pred(proj1(*begin1), proj2(*begin2)))
-                            break;
-                        ++begin1;
-                    }
-                    // *begin1 matches *begin2, now match elements after here
-                    auto m1 = begin1;
-                    I2 m2 = begin2;
-                    while(true)
-                    {
-                        if(++m2 == end2)  // If pattern exhausted, begin1 is the answer (works for 1 element pattern)
-                            return recounted(begin1_, std::move(begin1));
-                        ++m1;  // No need to check, we know we have room to match successfully
-                        if(!pred(proj1(*m1), proj2(*m2)))  // if there is a mismatch, restart with a new begin1
-                        {
-                            ++begin1;
-                            break;
-                        }  // else there is a match, check next elements
-                    }
-                }
-            }
-
             template<typename I1, typename S1, typename D1, typename I2, typename S2, typename D2,
                 typename C, typename P1, typename P2>
             static I1 sized_impl(I1 const begin1_, S1 end1, D1 const d1_, I2 begin2, S2 end2, D2 d2,

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -49,47 +49,6 @@ namespace ranges
         struct search_n_fn
         {
         private:
-            template<typename I, typename D, typename V, typename C, typename P,
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(RandomAccessIterator<I>::value)>
-#else
-                CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
-#endif
-            static I sized_impl(I const begin_, I end, D d, D count, V const &val,
-                C &pred, P &proj)
-            {
-                if(d < count)
-                    return end;
-                auto begin = uncounted(begin_);
-                auto const s = uncounted(end - (count - 1)); // Start of pattern match can't go beyond here
-                while(true)
-                {
-                    // Find first element in sequence that matches val, with a mininum of loop checks
-                    while(true)
-                    {
-                        if(begin >= s)  // return the end if we've run out of room
-                            return end;
-                        if(pred(proj(*begin), val))
-                            break;
-                        ++begin;
-                    }
-                    // *begin matches val, now match elements after here
-                    auto m = begin;
-                    D c = 0;
-                    while(true)
-                    {
-                        if(++c == count)  // If pattern exhausted, begin is the answer (works for 1 element pattern)
-                            return recounted(begin_, std::move(begin));
-                        ++m;  // No need to check, we know we have room to match successfully
-                        if(!pred(proj(*m), val))  // if there is a mismatch, restart with a new begin
-                        {
-                            begin = next(std::move(m));
-                            break;
-                        }  // else there is a match, check next elements
-                    }
-                }
-            }
-
             template<typename I, typename S, typename D, typename V, typename C, typename P>
             static I sized_impl(I const begin_, S end, D const d_, D count,
                 V const &val, C &pred, P &proj)

--- a/include/range/v3/algorithm/search_n.hpp
+++ b/include/range/v3/algorithm/search_n.hpp
@@ -42,7 +42,7 @@ namespace ranges
         template<typename I, typename V, typename C = equal_to, typename P = ident>
         using Searchnable = meta::fast_and<
             ForwardIterator<I>,
-            IndirectCallableRelation<C, Project<I, P>, V const *>>;
+            IndirectCallableRelation<C, Projected<I, P>, V const *>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/stable_partition.hpp
+++ b/include/range/v3/algorithm/stable_partition.hpp
@@ -48,7 +48,7 @@ namespace ranges
         using StablePartitionable = meta::fast_and<
             ForwardIterator<I>,
             Permutable<I>,
-            IndirectCallablePredicate<C, Project<I, P>>>;
+            IndirectCallablePredicate<C, Projected<I, P>>>;
 
         /// \addtogroup group-algorithms
         /// @{

--- a/include/range/v3/algorithm/stable_sort.hpp
+++ b/include/range/v3/algorithm/stable_sort.hpp
@@ -166,7 +166,7 @@ namespace ranges
                 using D = iterator_difference_t<I>;
                 using V = iterator_value_t<I>;
                 D len = end - begin;
-                auto buf = len > 256 ? std::get_temporary_buffer<V>(end - begin) : detail::value_init{};
+                auto buf = len > 256 ? std::get_temporary_buffer<V>(len) : detail::value_init{};
                 std::unique_ptr<V, detail::return_temporary_buffer> h{buf.first};
                 if(buf.first == nullptr)
                     stable_sort_fn::inplace_stable_sort(begin, end, pred, proj);

--- a/include/range/v3/algorithm/transform.hpp
+++ b/include/range/v3/algorithm/transform.hpp
@@ -41,7 +41,7 @@ namespace ranges
         using Transformable1 = meta::fast_and<
             InputIterator<I>,
             WeaklyIncrementable<O>,
-            IndirectCallable<F, Project<I, P>>,
+            IndirectCallable<F, Projected<I, P>>,
             Writable<O, Y>>;
 
         /// \ingroup group-concepts
@@ -56,7 +56,7 @@ namespace ranges
             InputIterator<I0>,
             WeakInputIterator<I1>,
             WeaklyIncrementable<O>,
-            IndirectCallable<F, Project<I0, P0>, Project<I1, P1>>,
+            IndirectCallable<F, Projected<I0, P0>, Projected<I1, P1>>,
             Writable<O, Y>>;
 
         /// \addtogroup group-algorithms

--- a/include/range/v3/algorithm/unique_copy.hpp
+++ b/include/range/v3/algorithm/unique_copy.hpp
@@ -33,7 +33,7 @@ namespace ranges
         template<typename I, typename O, typename C = equal_to, typename P = ident>
         using UniqueCopyable = meta::fast_and<
             InputIterator<I>,
-            IndirectCallableRelation<C, Project<I, P>>,
+            IndirectCallableRelation<C, Projected<I, P>>,
             WeaklyIncrementable<O>,
             IndirectlyCopyable<I, O>>;
 

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -139,6 +139,10 @@
 #define RANGES_WORKAROUND_MSVC_140392
 // friend with different nested template parameter level
 #define RANGES_WORKAROUND_MSVC_159890
+// constexpr + delegating constructors fail
+#define RANGES_WORKAROUND_MSVC_194815
+// using declaration w/ alias template: e.g. using foo::bar<T>::bar;
+#define RANGES_WORKAROUND_MSVC_206729
 // name lookup
 #define RANGES_WORKAROUND_MSVC_207089
 // alias template + parser error
@@ -175,6 +179,10 @@
 #define RANGES_WORKAROUND_MSVC_TEMPLATE_STATIC_INITIALIZER
 // nested alias template
 #define RANGES_WORKAROUND_MSVC_PACK_EXPANSION
+// variable template with deduced type
+#define RANGES_WORKAROUND_MSVC_AUTO_VARIABLE_TEMPLATE
+// class with operator() that privately inherits class with conversion to function pointer
+#define RANGES_WORKAROUND_MSVC_OPERATOR_ACCESS
 
 // Temporarily disable failing tests that still need workarounds.
 #define RANGES_DISABLE_MSVC_TEST_FAILURES

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -122,8 +122,6 @@
 
 #ifndef RANGES_NOT_PERMISSIVE
 // Workarounds that are unnecessary with /permissive-
-// alias template
-#define RANGES_WORKAROUND_MSVC_207134
 // Qualify names to avoid collisions with definitions in dependent base classes
 #define RANGES_WORKAROUND_MSVC_PERMISSIVE_DEPENDENT_BASE
 // "hidden" friend functions are not hidden. Relocate classes that declare hidden friends

--- a/include/range/v3/detail/config.hpp
+++ b/include/range/v3/detail/config.hpp
@@ -127,6 +127,8 @@
 // "hidden" friend functions are not hidden. Relocate classes that declare hidden friends
 // that would interfere with a customization point into nested namespaces.
 #define RANGES_WORKAROUND_MSVC_PERMISSIVE_HIDDEN_FRIEND
+// ~T() is valid - but does nothing - for array type T
+#define RANGES_WORKAROUND_MSVC_ARRAY_PSEUDO_DESTRUCTOR
 #endif
 
 // Enable the subset of the RANGES_WORKAROUND_MSVC_PERMISSIVE_HIDDEN_FRIEND changes that

--- a/include/range/v3/getlines.hpp
+++ b/include/range/v3/getlines.hpp
@@ -47,7 +47,7 @@ namespace ranges
                 {
                     rng_->next();
                 }
-                std::string const &current() const
+                std::string const &get() const
                 {
                     return rng_->str_;
                 }

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -47,7 +47,7 @@ namespace ranges
                 {
                     rng_->next();
                 }
-                Val const &current() const
+                Val const &get() const
                 {
                     return rng_->cached();
                 }

--- a/include/range/v3/istream_range.hpp
+++ b/include/range/v3/istream_range.hpp
@@ -64,10 +64,17 @@ namespace ranges
             {
                 return cursor{*this};
             }
+
+            istream_range(std::istream &sin, Val *)
+              : sin_(&sin), obj_{}
+            {}
+            istream_range(std::istream &sin, semiregular<Val> *)
+              : sin_(&sin), obj_{in_place}
+            {}
         public:
             istream_range() = default;
             istream_range(std::istream &sin)
-              : sin_(&sin), obj_{}
+              : istream_range(sin, _nullptr_v<semiregular_t<Val>>())
             {
                 next(); // prime the pump
             }
@@ -81,10 +88,16 @@ namespace ranges
         template<typename Val>
         istream_range<Val> istream(std::istream & sin)
         {
+            CONCEPT_ASSERT_MSG(DefaultConstructible<Val>(),
+               "Only DefaultConstructible types are extractable from streams.");
             return istream_range<Val>{sin};
         }
     #else
-        template<typename Val>
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+        template<typename Val, CONCEPT_REQUIRES_(DefaultConstructible<Val>::value)>
+#else
+        template<typename Val, CONCEPT_REQUIRES_(DefaultConstructible<Val>())>
+#endif
         struct istream_fn
         {
             istream_range<Val> operator()(std::istream & sin) const

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -402,11 +402,6 @@ namespace ranges
             {
                 using type = typename RangeFacade::view_facade_t;
             };
-            template<typename RangeAdaptor>
-            struct view_adaptor
-            {
-                using type = typename RangeAdaptor::view_adaptor_t;
-            };
             /// endcond
         };
         /// @}

--- a/include/range/v3/range_access.hpp
+++ b/include/range/v3/range_access.hpp
@@ -32,20 +32,35 @@ namespace ranges
 
             //
             // Concepts that the range cursor must model
-            // BUGBUG this doesn't handle weak cursors.
             //
-            struct InputCursorConcept
+            struct WeakCursor
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
                     concepts::valid_expr(
-                        //t.done(),
-                        t.current(),
                         (t.next(), concepts::void_)
                     ));
             };
-            struct ForwardCursorConcept
-              : concepts::refines<InputCursorConcept>
+            struct WeakInputCursor
+              : concepts::refines<WeakCursor>
+            {
+                template<typename T>
+                auto requires_(T&& t) -> decltype(
+                    concepts::valid_expr(
+                        t.current()
+                    ));
+            };
+            struct InputCursor
+              : concepts::refines<WeakInputCursor>
+            {
+                template<typename T>
+                auto requires_(T&& t) -> decltype(
+                    concepts::valid_expr(
+                        t.done()
+                    ));
+            };
+            struct ForwardCursor
+              : concepts::refines<WeakInputCursor>
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
@@ -53,8 +68,8 @@ namespace ranges
                         concepts::convertible_to<bool>(t.equal(t))
                     ));
             };
-            struct BidirectionalCursorConcept
-              : concepts::refines<ForwardCursorConcept>
+            struct BidirectionalCursor
+              : concepts::refines<ForwardCursor>
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
@@ -62,8 +77,8 @@ namespace ranges
                         (t.prev(), concepts::void_)
                     ));
             };
-            struct RandomAccessCursorConcept
-              : concepts::refines<BidirectionalCursorConcept>
+            struct RandomAccessCursor
+              : concepts::refines<BidirectionalCursor>
             {
                 template<typename T>
                 auto requires_(T&& t) -> decltype(
@@ -72,7 +87,7 @@ namespace ranges
                         (t.advance(t.distance_to(t)), concepts::void_)
                     ));
             };
-            struct InfiniteCursorConcept
+            struct InfiniteCursor
             {
                 template<typename T>
                 auto requires_(T&&) -> decltype(
@@ -292,33 +307,42 @@ namespace ranges
         namespace detail
         {
             template<typename T>
+            using WeakCursor =
+                concepts::models<range_access::WeakCursor, T>;
+
+            template<typename T>
+            using WeakInputCursor =
+                concepts::models<range_access::WeakInputCursor, T>;
+
+            template<typename T>
             using InputCursor =
-                concepts::models<range_access::InputCursorConcept, T>;
+                concepts::models<range_access::InputCursor, T>;
 
             template<typename T>
             using ForwardCursor =
-                concepts::models<range_access::ForwardCursorConcept, T>;
+                concepts::models<range_access::ForwardCursor, T>;
 
             template<typename T>
             using BidirectionalCursor =
-                concepts::models<range_access::BidirectionalCursorConcept, T>;
+                concepts::models<range_access::BidirectionalCursor, T>;
 
             template<typename T>
             using RandomAccessCursor =
-                concepts::models<range_access::RandomAccessCursorConcept, T>;
+                concepts::models<range_access::RandomAccessCursor, T>;
 
             template<typename T>
             using InfiniteCursor =
-                concepts::models<range_access::InfiniteCursorConcept, T>;
+                concepts::models<range_access::InfiniteCursor, T>;
 
             template<typename T>
             using cursor_concept =
                 concepts::most_refined<
                     meta::list<
-                        range_access::RandomAccessCursorConcept,
-                        range_access::BidirectionalCursorConcept,
-                        range_access::ForwardCursorConcept,
-                        range_access::InputCursorConcept>, T>;
+                        range_access::RandomAccessCursor,
+                        range_access::BidirectionalCursor,
+                        range_access::ForwardCursor,
+                        range_access::InputCursor,
+                        range_access::WeakInputCursor>, T>;
 
             template<typename T>
             using cursor_concept_t = meta::_t<cursor_concept<T>>;

--- a/include/range/v3/range_concepts.hpp
+++ b/include/range/v3/range_concepts.hpp
@@ -60,21 +60,28 @@ namespace ranges
             {
                 // Associated types
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_ALIAS_DECLTYPE
+            private:
                 template<typename>
                 using iterator_t_helper_void_t = void;
                 template<typename, typename = void> struct iterator_t_helper {};
-                template<typename T> struct iterator_t_helper<T, iterator_t_helper_void_t<decltype(begin(std::declval<T&>()))>> {
+                template<typename T>
+                struct iterator_t_helper<T, iterator_t_helper_void_t<decltype(begin(std::declval<T&>()))>>
+                {
                     using type = decltype(begin(std::declval<T&>()));
                 };
-                template<typename T>
-                using iterator_t = meta::_t<iterator_t_helper<T>>;
 
                 template<typename>
                 using sentinel_t_helper_void_t = void;
                 template<typename, typename = void> struct sentinel_t_helper {};
-                template<typename T> struct sentinel_t_helper<T, sentinel_t_helper_void_t<decltype(end(std::declval<T&>()))>> {
+                template<typename T>
+                struct sentinel_t_helper<T, sentinel_t_helper_void_t<decltype(end(std::declval<T&>()))>>
+                {
                     using type = decltype(end(std::declval<T&>()));
                 };
+            public:
+                template<typename T>
+                using iterator_t = meta::_t<iterator_t_helper<T>>;
+
                 template<typename T>
                 using sentinel_t = meta::_t<sentinel_t_helper<T>>;
 #else

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -244,8 +244,6 @@ namespace ranges
             template<typename I, typename D = meta::_t<difference_type<I>>>
             struct counted_cursor;
 
-            struct counted_sentinel;
-
             template<typename Int>
             struct from_end_;
 
@@ -434,12 +432,12 @@ namespace ranges
             struct counted_fn;
         }
 
+        struct default_end_cursor;
+        using default_sentinel = basic_sentinel<default_end_cursor>;
+
         template<typename I, typename D = meta::_t<difference_type<I>>>
         using counted_iterator =
-            basic_iterator<detail::counted_cursor<I, D>, detail::counted_sentinel>;
-
-        using counted_sentinel =
-            basic_sentinel<detail::counted_sentinel>;
+            basic_iterator<detail::counted_cursor<I, D>, default_end_cursor>;
 
         template<typename Rng>
         struct cycled_view;
@@ -449,10 +447,12 @@ namespace ranges
             struct cycle_fn;
         }
 
+        /// \cond
         namespace detail
         {
             template<typename I> struct reverse_cursor;
         }
+        /// \endcond
 
         template<typename I>
         using reverse_iterator = basic_iterator<detail::reverse_cursor<I>,

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -376,8 +376,10 @@ namespace ranges
         template<typename T>
         struct istream_range;
 
+    #if !RANGES_CXX_VARIABLE_TEMPLATES
         template<typename T>
         istream_range<T> istream(std::istream & sin);
+    #endif
 
         template<typename I, typename S = I>
         struct range;

--- a/include/range/v3/to_container.hpp
+++ b/include/range/v3/to_container.hpp
@@ -67,7 +67,7 @@ namespace ranges
                 Cont impl(Rng && rng, std::false_type) const
                 {
                     using I = range_common_iterator_t<Rng>;
-                    return Cont{I{begin(rng)}, I{end(rng)}};
+                    return Cont(I{begin(rng)}, I{end(rng)});
                 }
 
                 template<typename Rng,

--- a/include/range/v3/utility/any.hpp
+++ b/include/range/v3/utility/any.hpp
@@ -104,7 +104,7 @@ namespace ranges
                 impl(T o) : obj(std::move(o)) {}
                 T &get() { return obj; }
                 T const &get() const { return obj; }
-                interface *clone() const override
+                impl *clone() const override
                 {
                     return new impl{obj};
                 }
@@ -117,11 +117,10 @@ namespace ranges
             std::unique_ptr<interface> ptr_;
         public:
             any() noexcept = default;
-            template<typename T,
-                CONCEPT_REQUIRES_(Copyable<T>() &&
-                    !Same<detail::decay_t<T>, any>())>
-            any(T &&t)
-              : ptr_(new impl<detail::decay_t<T>>(std::forward<T>(t)))
+            template<typename TRef, typename T = detail::decay_t<TRef>,
+                CONCEPT_REQUIRES_(Copyable<T>() && !Same<T, any>())>
+            any(TRef &&t)
+              : ptr_(new impl<T>(std::forward<TRef>(t)))
             {}
             any(any &&) noexcept = default;
             any(any const &that)
@@ -133,12 +132,11 @@ namespace ranges
                 ptr_.reset(that.ptr_ ? that.ptr_->clone() : nullptr);
                 return *this;
             }
-            template<typename T,
-                CONCEPT_REQUIRES_(Copyable<T>() &&
-                    !Same<detail::decay_t<T>, any>())>
-            any &operator=(T &&t)
+            template<typename TRef, typename T = detail::decay_t<TRef>,
+                CONCEPT_REQUIRES_(Copyable<T>() && !Same<T, any>())>
+            any &operator=(TRef &&t)
             {
-                any{std::forward<T>(t)}.swap(*this);
+                any{std::forward<TRef>(t)}.swap(*this);
                 return *this;
             }
             void clear() noexcept

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -194,13 +194,15 @@ namespace ranges
             template<typename Cur>
             using mixin_base = meta::_t<mixin_base_<Cur>>;
 
-            auto iter_cat(range_access::InputCursorConcept*) ->
+            auto iter_cat(range_access::WeakInputCursor*) ->
+                ranges::weak_input_iterator_tag;
+            auto iter_cat(range_access::InputCursor*) ->
                 ranges::input_iterator_tag;
-            auto iter_cat(range_access::ForwardCursorConcept*) ->
+            auto iter_cat(range_access::ForwardCursor*) ->
                 ranges::forward_iterator_tag;
-            auto iter_cat(range_access::BidirectionalCursorConcept*) ->
+            auto iter_cat(range_access::BidirectionalCursor*) ->
                 ranges::bidirectional_iterator_tag;
-            auto iter_cat(range_access::RandomAccessCursorConcept*) ->
+            auto iter_cat(range_access::RandomAccessCursor*) ->
                 ranges::random_access_iterator_tag;
         }
         /// \endcond
@@ -300,17 +302,24 @@ namespace ranges
             friend detail::mixin_base<Cur>;
             template<typename OtherCur, typename OtherS>
             friend struct basic_iterator;
+            // TODO support output iterators
+            //CONCEPT_ASSERT(detail::WeakCursor<Cur>());
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-            CONCEPT_ASSERT(detail::InputCursor<Cur>::value);
+            CONCEPT_ASSERT(detail::WeakInputCursor<Cur>::value);
 #else
-            CONCEPT_ASSERT(detail::InputCursor<Cur>());
+            CONCEPT_ASSERT(detail::WeakInputCursor<Cur>());
 #endif
             using single_pass = range_access::single_pass_t<Cur>;
+            using is_weak_t =
+                std::is_same<detail::cursor_concept_t<Cur>, range_access::WeakInputCursor>;
             using cursor_concept_t =
                 meta::if_<
-                    single_pass,
-                    range_access::InputCursorConcept,
-                    detail::cursor_concept_t<Cur>>;
+                    is_weak_t,
+                    range_access::WeakInputCursor,
+                    meta::if_<
+                        single_pass,
+                        range_access::InputCursor,
+                        detail::cursor_concept_t<Cur>>>;
 
 #ifdef RANGES_WORKAROUND_MSVC_214062
             template<typename T> struct helper {
@@ -329,30 +338,25 @@ namespace ranges
                 return this->detail::mixin_base<Cur>::get();
             }
 
-            // If Range models RangeFacade or if the cursor models
-            // ForwardCursor, then positions must be equality comparable.
-            // Otherwise, it's an InputCursor in an RangeFacade, so
-            // all cursors are trivially equal.
-            // BUGBUG this doesn't handle weak iterators.
-            constexpr bool equal2_(basic_iterator const&,
-                range_access::InputCursorConcept *) const
+            // If the cursor models ForwardCursor, then positions are equality comparable.
+            // Otherwise, make all cursors are trivially equal.
+            constexpr bool equal2_(basic_iterator const&, range_access::InputCursor *) const
             {
                 return true;
             }
-            constexpr bool equal2_(basic_iterator const &that,
-                range_access::ForwardCursorConcept *) const
+            constexpr bool equal2_(basic_iterator const &that, range_access::ForwardCursor *) const
             {
                 return range_access::equal(pos(), that.pos());
             }
-            constexpr bool equal_(basic_iterator const &that,
-                std::false_type *) const
+            // For Bounded ranges:
+            constexpr bool equal_(basic_iterator const &that, std::true_type *) const
+            {
+                return range_access::equal(pos(), that.pos());
+            }
+            // For non-Bounded ranges:
+            constexpr bool equal_(basic_iterator const &that, std::false_type *) const
             {
                 return basic_iterator::equal2_(that, _nullptr_v<cursor_concept_t>());
-            }
-            constexpr bool equal_(basic_iterator const &that,
-                std::true_type *) const
-            {
-                return range_access::equal(pos(), that.pos());
             }
         public:
             using reference =
@@ -404,32 +408,61 @@ namespace ranges
                 ++*this;
                 return tmp;
             }
-            // BUGBUG this doesn't handle weak iterators.
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR_FRIEND
+            CONCEPT_REQUIRES_FRIEND(!is_weak_t::value)
+#else
+            CONCEPT_REQUIRES(!is_weak_t())
+#endif
             friend constexpr bool operator==(basic_iterator const &left,
                 basic_iterator const &right)
             {
                 return left.equal_(right, _nullptr_v<std::is_same<Cur, S>>());
             }
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR_FRIEND
+            CONCEPT_REQUIRES_FRIEND(!is_weak_t::value)
+#else
+            CONCEPT_REQUIRES(!is_weak_t())
+#endif
             friend constexpr bool operator!=(basic_iterator const &left,
                 basic_iterator const &right)
             {
                 return !(left == right);
             }
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR_FRIEND
+            CONCEPT_REQUIRES_FRIEND(!is_weak_t::value)
+#else
+            CONCEPT_REQUIRES(!is_weak_t())
+#endif
             friend constexpr bool operator==(basic_iterator const &left,
                 basic_sentinel<S> const &right)
             {
                 return range_access::empty(left.pos(), right.end());
             }
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR_FRIEND
+            CONCEPT_REQUIRES_FRIEND(!is_weak_t::value)
+#else
+            CONCEPT_REQUIRES(!is_weak_t())
+#endif
             friend constexpr bool operator!=(basic_iterator const &left,
                 basic_sentinel<S> const &right)
             {
                 return !(left == right);
             }
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR_FRIEND
+            CONCEPT_REQUIRES_FRIEND(!is_weak_t::value)
+#else
+            CONCEPT_REQUIRES(!is_weak_t())
+#endif
             friend constexpr bool operator==(basic_sentinel<S> const & left,
                 basic_iterator const &right)
             {
                 return range_access::empty(right.pos(), left.end());
             }
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR_FRIEND
+            CONCEPT_REQUIRES_FRIEND(!is_weak_t::value)
+#else
+            CONCEPT_REQUIRES(!is_weak_t())
+#endif
             friend constexpr bool operator!=(basic_sentinel<S> const &left,
                 basic_iterator const &right)
             {

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -604,7 +604,7 @@ namespace ranges
         public:
             using base_t::base_t;
 #else
-            using range_access::mixin_base_t<Cur>::mixin_base_t;
+            using range_access::mixin_base_t<S>::mixin_base_t;
 #endif
             constexpr bool operator==(basic_sentinel<S> const &) const noexcept
             {

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -412,12 +412,12 @@ namespace ranges
                 return tmp;
             }
             // BUGBUG this doesn't handle weak iterators.
-            constexpr friend bool operator==(basic_iterator const &left,
+            friend constexpr bool operator==(basic_iterator const &left,
                 basic_iterator const &right)
             {
                 return left.equal_(right, _nullptr_v<std::is_same<Cur, S>>());
             }
-            constexpr friend bool operator!=(basic_iterator const &left,
+            friend constexpr bool operator!=(basic_iterator const &left,
                 basic_iterator const &right)
             {
                 return !(left == right);

--- a/include/range/v3/utility/basic_iterator.hpp
+++ b/include/range/v3/utility/basic_iterator.hpp
@@ -44,7 +44,6 @@ namespace ranges
             private:
                 mutable value_type value_;
             public:
-                RANGES_CXX14_CONSTEXPR
                 postfix_increment_proxy() = default;
                 RANGES_CXX14_CONSTEXPR
                 explicit postfix_increment_proxy(I const& x)
@@ -75,7 +74,6 @@ namespace ranges
                 mutable value_type value_;
                 I it_;
             public:
-                RANGES_CXX14_CONSTEXPR
                 writable_postfix_increment_proxy() = default;
                 RANGES_CXX14_CONSTEXPR
                 explicit writable_postfix_increment_proxy(I x)
@@ -174,17 +172,12 @@ namespace ranges
             template<typename I, typename Val, typename Ref, typename Cat>
             using postfix_increment_result =
                 meta::if_<
-                    meta::and_<
-                        // A proxy is only needed for readable iterators
-                        std::is_convertible<Ref, Val const &>,
-                        // No forward iterator can have values that disappear
-                        // before positions can be re-visited
-                        meta::not_<DerivedFrom<Cat, ranges::forward_iterator_tag>>>,
+                    DerivedFrom<Cat, ranges::forward_iterator_tag>,
+                    I,
                     meta::if_<
                         is_non_proxy_reference<Ref, Val>,
                         postfix_increment_proxy<I>,
-                        writable_postfix_increment_proxy<I>>,
-                    I>;
+                        writable_postfix_increment_proxy<I>>>;
 
             template<typename Cur, typename Enable = void>
             struct mixin_base_
@@ -278,7 +271,7 @@ namespace ranges
             using detail::mixin_base<S>::get;
 #endif
         public:
-            RANGES_CXX14_CONSTEXPR basic_sentinel() = default;
+            basic_sentinel() = default;
             RANGES_CXX14_CONSTEXPR basic_sentinel(S end)
               : detail::mixin_base<S>(std::move(end))
             {}

--- a/include/range/v3/utility/box.hpp
+++ b/include/range/v3/utility/box.hpp
@@ -132,7 +132,13 @@ namespace ranges
 
         static_assert(std::is_trivial<constant<int, 0>>::value, "Expected constant to be trivial");
 
-        template<typename Element, typename Tag = Element, bool Empty = std::is_empty<Element>::value>
+        template<typename Element, typename Tag = Element,
+            bool Empty = std::is_empty<Element>::value &&
+#if RANGES_CXX_LIB_IS_FINAL >= RANGES_CXX_LIB_IS_FINAL_14
+                         !std::is_final<Element>::value>
+#else
+                         true>
+#endif
         struct box
         {
             Element value;
@@ -183,7 +189,7 @@ namespace ranges
 
         // Get by tag type
         template<typename Tag, typename Element>
-        Element & get(box<Element, Tag, false> & b)
+        constexpr Element & get(box<Element, Tag, false> & b)
         {
             return b.value;
         }
@@ -201,7 +207,7 @@ namespace ranges
         }
 
         template<typename Tag, typename Element>
-        Element & get(box<Element, Tag, true> & b)
+        constexpr Element & get(box<Element, Tag, true> & b)
         {
             return b;
         }
@@ -220,7 +226,7 @@ namespace ranges
 
         // Get by index
         template<std::size_t I, typename Element>
-        Element & get(box<Element, std::integral_constant<std::size_t, I>, false> & b)
+        constexpr Element & get(box<Element, std::integral_constant<std::size_t, I>, false> & b)
         {
             return b.value;
         }
@@ -238,7 +244,7 @@ namespace ranges
         }
 
         template<std::size_t I, typename Element>
-        Element & get(box<Element, std::integral_constant<std::size_t, I>, true> & b)
+        constexpr Element & get(box<Element, std::integral_constant<std::size_t, I>, true> & b)
         {
             return b;
         }

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -517,7 +517,11 @@ namespace ranges
             struct Destructible
             {
                 template<typename T,
+#ifdef RANGES_WORKAROUND_MSVC_ARRAY_PSEUDO_DESTRUCTOR
+                    meta::if_c<std::is_object<T>::value && !std::is_array<T>::value, int> = 0>
+#else  // RANGES_WORKAROUND_MSVC_ARRAY_PSEUDO_DESTRUCTOR
                     meta::if_<std::is_object<T>, int> = 0>
+#endif // RANGES_WORKAROUND_MSVC_ARRAY_PSEUDO_DESTRUCTOR
                 auto requires_(T && t, T* const p = nullptr) -> decltype(
                     concepts::valid_expr(
                         (t.~T(), 42),

--- a/include/range/v3/utility/concepts.hpp
+++ b/include/range/v3/utility/concepts.hpp
@@ -552,10 +552,11 @@ namespace ranges
                 // Avoid CWG DR1467.
                 template<typename T, typename U>
                 using DR1467 =
-#if defined(__clang__) && (__clang_major__ < 3 || ( __clang_major__ == 3 && __clang_minor__ <= 4))
+#if defined(__clang__) && (__clang_major__ < 3 || ( __clang_major__ == 3 && __clang_minor__ <= 4) || (__clang_major__ == 6 && __clang_minor__ == 0))
                   // 3.4 has a bug involving uniform initialization and conversion operators,
                   // so just avoid brace initialization in all cases for construction from a
                   // single argument.
+                  // also: Apple clang 3.5 seemingly still has the bug and reports its version incorrectly (__clang_major__ == 6 && __clang_minor__ == 0)
                   meta::bool_<true || std::is_same<T, U>::value>;
 #else
                   std::is_same<uncvref_t<T>, uncvref_t<U>>;

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -236,6 +236,16 @@ namespace ranges
         {
             return 0;
         }
+
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+        template<typename I, CONCEPT_REQUIRES_(WeakInputIterator<I>::value)>
+#else
+        template<typename I, CONCEPT_REQUIRES_(WeakInputIterator<I>())>
+#endif
+        counted_iterator<I> make_counted_iterator(I i, iterator_difference_t<I> n)
+        {
+            return counted_iterator<I>{std::move(i), n};
+        }
         /// @}
     }
 }

--- a/include/range/v3/utility/counted_iterator.hpp
+++ b/include/range/v3/utility/counted_iterator.hpp
@@ -87,7 +87,6 @@ namespace ranges
                     }
                 };
             private:
-                friend struct counted_sentinel;
                 template<typename OtherI, typename OtherD>
                 friend struct counted_cursor;
                 using iterator_concept_ =
@@ -132,9 +131,13 @@ namespace ranges
                 counted_cursor(counted_cursor<OtherI, OtherD> that)
                   : it_(std::move(that.it_)), n_(std::move(that.n_))
                 {}
-                auto current() const -> decltype(*it_)
+                auto get() const -> decltype(*it_)
                 {
                     return *it_;
+                }
+                bool done() const
+                {
+                    return 0 == n_;
                 }
                 void next()
                 {
@@ -170,15 +173,13 @@ namespace ranges
                     it_ += n;
                     n_ -= n;
                 }
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES(RandomAccessIterator<I>::value)
-#else
-                CONCEPT_REQUIRES(RandomAccessIterator<I>())
-#endif
-                iterator_difference_t<I>
-                distance_to(counted_cursor<I> const &that) const
+                D distance_to(counted_cursor<I> const &that) const
                 {
                     return n_ - that.n_;
+                }
+                D distance_remaining() const
+                {
+                    return n_;
                 }
                 I base() const
                 {
@@ -189,53 +190,11 @@ namespace ranges
                     return n_;
                 }
             };
-
-            struct counted_sentinel
-            {
-                template<typename I, typename D>
-                bool equal(counted_cursor<I, D> const &that) const
-                {
-                    return that.n_ == 0;
-                }
-            };
         }
         /// \endcond
 
         /// \addtogroup group-utility
         /// @{
-
-        // For RandomAccessIterator, operator- will be defined by basic_iterator
-        template<typename I0, typename D0, typename I1, typename D1,
-            typename CI = detail::UnambiguouslyConvertibleType<I0, I1>,
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-            CONCEPT_REQUIRES_(detail::UnambiguouslyConvertible<I0, I1>::value &&
-                !RandomAccessIterator<CI>::value)>
-#else
-            CONCEPT_REQUIRES_(detail::UnambiguouslyConvertible<I0, I1>() &&
-                !RandomAccessIterator<CI>())>
-#endif
-        iterator_difference_t<CI>
-        operator-(counted_iterator<I0, D0> const &end, counted_iterator<I1, D1> const &begin)
-        {
-            return begin.count() - end.count();
-        }
-
-        template<typename I, typename D>
-        iterator_difference_t<I> operator-(counted_sentinel const &end, counted_iterator<I, D> const &begin)
-        {
-            return begin.count();
-        }
-
-        template<typename I, typename D>
-        iterator_difference_t<I> operator-(counted_iterator<I, D> const &begin, counted_sentinel const &end)
-        {
-            return -begin.count();
-        }
-
-        inline std::ptrdiff_t operator-(counted_sentinel const &, counted_sentinel const &)
-        {
-            return 0;
-        }
 
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
         template<typename I, CONCEPT_REQUIRES_(WeakInputIterator<I>::value)>

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -213,56 +213,35 @@ namespace ranges
         struct logical_negate
         {
         private:
-            Pred pred_;
+            using fn_t = meta::_t<std::decay<function_type<Pred>>>;
+            fn_t pred_;
         public:
             logical_negate() = default;
 
             explicit constexpr logical_negate(Pred pred)
-              : pred_((Pred &&) pred)
+              : pred_(as_function((Pred &&) pred))
             {}
 
-            template<typename T,
+            template<typename ...Args,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(Predicate<Pred, T>::value)>
+                CONCEPT_REQUIRES_(Predicate<fn_t&, Args...>::value)>
 #else
-                CONCEPT_REQUIRES_(Predicate<Pred, T>())>
+                CONCEPT_REQUIRES_(Predicate<fn_t&, Args...>())>
 #endif
-            bool operator()(T && t)
+            bool operator()(Args &&...args)
             {
-                return !pred_((T &&) t);
+                return !pred_(((Args &&) args)...);
             }
             /// \overload
-            template<typename T,
+            template<typename ...Args,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(Predicate<Pred const, T>::value)>
+                CONCEPT_REQUIRES_(Predicate<fn_t const&, Args...>::value)>
 #else
-                CONCEPT_REQUIRES_(Predicate<Pred const, T>())>
+                CONCEPT_REQUIRES_(Predicate<fn_t const&, Args...>())>
 #endif
-            constexpr bool operator()(T && t) const
+            constexpr bool operator()(Args &&...args) const
             {
-                return !pred_((T &&) t);
-            }
-            /// \overload
-            template<typename T, typename U,
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(Predicate<Pred, T, U>::value)>
-#else
-                CONCEPT_REQUIRES_(Predicate<Pred, T, U>())>
-#endif
-            bool operator()(T && t, U && u)
-            {
-                return !pred_((T &&) t, (U &&) u);
-            }
-            /// \overload
-            template<typename T, typename U,
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(Predicate<Pred const, T, U>::value)>
-#else
-                CONCEPT_REQUIRES_(Predicate<Pred const, T, U>())>
-#endif
-            constexpr bool operator()(T && t, U && u) const
-            {
-                return !pred_((T &&) t, (U &&) u);
+                return !pred_(((Args &&) args)...);
             }
         };
 

--- a/include/range/v3/utility/functional.hpp
+++ b/include/range/v3/utility/functional.hpp
@@ -43,6 +43,7 @@ namespace ranges
             {
                 return (T &&) t == (U &&) u;
             }
+            using is_transparent = void;
         };
 
         struct less
@@ -57,6 +58,7 @@ namespace ranges
             {
                 return (T &&) t < (U &&) u;
             }
+            using is_transparent = void;
         };
 
         struct ordered_less
@@ -71,6 +73,7 @@ namespace ranges
             {
                 return (T &&) t < (U &&) u;
             }
+            using is_transparent = void;
         };
 
         struct ident
@@ -80,6 +83,7 @@ namespace ranges
             {
                 return (T &&) t;
             }
+            using is_transparent = void;
         };
 
         struct plus
@@ -90,6 +94,7 @@ namespace ranges
             {
                 return (T &&) t + (U &&) u;
             }
+            using is_transparent = void;
         };
 
         struct minus
@@ -100,6 +105,7 @@ namespace ranges
             {
                 return (T &&) t - (U &&) u;
             }
+            using is_transparent = void;
         };
 
         struct multiplies
@@ -110,6 +116,7 @@ namespace ranges
             {
                 return (T &&) t * (U &&) u;
             }
+            using is_transparent = void;
         };
 
         struct bitwise_or
@@ -120,6 +127,7 @@ namespace ranges
             {
                 return (T &&) t | (U &&) u;
             }
+            using is_transparent = void;
         };
 
         template<typename T>
@@ -172,19 +180,38 @@ namespace ranges
         /// \addtogroup group-utility
         struct as_function_fn
         {
-            template<typename T, typename U = detail::decay_t<T>,
-                CONCEPT_REQUIRES_(std::is_member_pointer<U>::value)>
-            auto operator()(T && t) const
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                std::mem_fn(t)
-            )
-            template<typename T, typename U = detail::decay_t<T>,
-                CONCEPT_REQUIRES_(!std::is_member_pointer<U>::value)>
-            T operator()(T && t) const
-                noexcept(std::is_nothrow_constructible<T, T>::value)
+        private:
+            template<typename R, typename...Args>
+            struct ptr_fn_
             {
-                return std::forward<T>(t);
+            private:
+                R (*pfn_)(Args...);
+            public:
+                ptr_fn_() = default;
+                constexpr explicit ptr_fn_(R (*pfn)(Args...))
+                  : pfn_(pfn)
+                {}
+                R operator()(Args...args) const
+                {
+                    return (*pfn_)(std::forward<Args>(args)...);
+                }
+            };
+        public:
+            template<typename R, typename ...Args>
+            constexpr ptr_fn_<R, Args...> operator()(R (*p)(Args...)) const
+            {
+                return ptr_fn_<R, Args...>(p);
+            }
+            template<typename R, typename T>
+            auto operator()(R T::* p) const -> decltype(std::mem_fn(p))
+            {
+                return std::mem_fn(p);
+            }
+            template<typename T, typename U = detail::decay_t<T>>
+            constexpr auto operator()(T && t) const ->
+                meta::if_c<!std::is_pointer<U>::value && !std::is_member_pointer<U>::value, T>
+            {
+                return detail::forward<T>(t);
             }
         };
 
@@ -408,6 +435,57 @@ namespace ranges
         namespace
         {
             constexpr auto&& indirect = static_const<indirect_fn>::value;
+        }
+
+        template<typename Fn1, typename Fn2>
+        struct transformed
+          : private function_type<Fn1>
+          , private function_type<Fn2>
+        {
+        private:
+            using BaseFn1 = function_type<Fn1>;
+            using BaseFn2 = function_type<Fn2>;
+
+            BaseFn1 & fn1()              { return *this; }
+            BaseFn1 const & fn1() const  { return *this; }
+            BaseFn2 & fn2()              { return *this; }
+            BaseFn2 const & fn2() const  { return *this; }
+        public:
+            transformed() = default;
+            constexpr transformed(Fn1 fn1, Fn2 fn2)
+              : BaseFn1(as_function(detail::move(fn1)))
+              , BaseFn2(as_function(detail::move(fn2)))
+            {}
+            template<typename ...Args>
+            auto operator()(Args &&... args)
+              noexcept(noexcept(std::declval<BaseFn1 &>()(std::declval<BaseFn2 &>()(std::forward<Args>(args))...))) ->
+              decltype(std::declval<BaseFn1 &>()(std::declval<BaseFn2 &>()(std::forward<Args>(args))...))
+            {
+                return fn1()(fn2()(std::forward<Args>(args)...));
+            }
+            template<typename ...Args>
+            auto operator()(Args &&... args) const
+              noexcept(noexcept(std::declval<BaseFn1 const &>()(std::declval<BaseFn2 const &>()(std::forward<Args>(args))...))) ->
+              decltype(std::declval<BaseFn1 const &>()(std::declval<BaseFn2 const &>()(std::forward<Args>(args))...))
+            {
+                return fn1()(fn2()(std::forward<Args>(args)...));
+            }
+        };
+
+        struct on_fn
+        {
+            template<typename Fn1, typename Fn2>
+            constexpr transformed<Fn1, Fn2> operator()(Fn1 fn1, Fn2 fn2) const
+            {
+                return transformed<Fn1, Fn2>{detail::move(fn1), detail::move(fn2)};
+            }
+        };
+
+        /// \ingroup group-utility
+        /// \sa `on_fn`
+        namespace
+        {
+            constexpr auto&& on = static_const<on_fn>::value;
         }
 
         /// \cond

--- a/include/range/v3/utility/iterator.hpp
+++ b/include/range/v3/utility/iterator.hpp
@@ -709,12 +709,6 @@ namespace ranges
                 return i;
             }
 
-            template<typename I>
-            constexpr I recounted(I const &, I i)
-            {
-                return i;
-            }
-
             struct uncounted_fn
             {
                 template<typename I>
@@ -734,14 +728,6 @@ namespace ranges
                     decltype(recounted((I&&)i, (J&&)j, n))
                 {
                     return recounted((I&&)i, (J&&)j, n);
-                }
-
-                template<typename I, typename J>
-                constexpr
-                auto operator()(I i, J j) const ->
-                    decltype(recounted((I&&)i, (J&&)j))
-                {
-                    return recounted((I&&)i, (J&&)j);
                 }
             };
         }

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -469,23 +469,24 @@ namespace ranges
         {
             // Return the value and reference types of an iterator in a list.
             template<typename I>
-            using readable_types =
+            using readable_types_ =
                 meta::list<concepts::Readable::value_t<I>, concepts::Readable::reference_t<I>>;
 
-            template<typename CombineFn, typename ApplyFn, typename...Is>
-            using indirect_apply_combine =
-                // Collect the list of results computed below with CombineFn
-                meta::apply_list<
-                    CombineFn,
-                    // Call ApplyFn with the cartesian product of the Readables' value and reference
-                    // types. In addition, call ApplyFn with the common_reference type of all the
-                    // Readables. Return all the results as a list.
-                    meta::transform<
-                        meta::push_back<
-                            meta::cartesian_product<
-                                meta::transform<meta::list<Is...>, meta::quote<readable_types>>>,
-                            meta::list<concepts::Readable::common_reference_t<Is>...>>,
-                        meta::bind_front<meta::quote<meta::apply_list>, ApplyFn>>>;
+            // Call ApplyFn with the cartesian product of the Readables' value and reference
+            // types. In addition, call ApplyFn with the common_reference type of all the
+            // Readables. Return all the results as a list.
+            template<class...Is>
+            using iter_args_lists_ =
+                meta::push_back<
+                    meta::cartesian_product<
+                        meta::transform<meta::list<Is...>, meta::quote<readable_types_>>>,
+                    meta::list<concepts::Readable::common_reference_t<Is>...>>;
+
+            template<typename ReduceFn, typename MapFn>
+            using iter_map_reduce_fn_ =
+                meta::compose<
+                    meta::uncurry<meta::on<ReduceFn, meta::uncurry<MapFn>>>,
+                    meta::quote<iter_args_lists_>>;
         }
 
         template<typename C, typename ...Is>
@@ -493,35 +494,35 @@ namespace ranges
             meta::fast_and<Readable<Is>...>,
             // C must be callable with the values and references read from the Is.
             meta::lazy::apply<
-                meta::quote<detail::indirect_apply_combine>,
-                meta::quote<meta::fast_and>,
-                meta::bind_front<meta::quote<Function>, C>,
+                detail::iter_map_reduce_fn_<
+                    meta::quote<meta::fast_and>,
+                    meta::bind_front<meta::quote<Function>, C>>,
                 Is...>,
             // In addition, the return types of the C invocations tried above must all
             // share a common reference type. (The lazy::apply is so that this doesn't get
             // evaluated unless C is truly callable as determined above.)
             meta::lazy::apply<
-                meta::quote<detail::indirect_apply_combine>,
-                meta::quote<CommonReference>,
-                meta::bind_front<meta::quote<concepts::Function::result_t>, C>,
+                detail::iter_map_reduce_fn_<
+                    meta::quote<CommonReference>,
+                    meta::bind_front<meta::quote<concepts::Function::result_t>, C>>,
                 Is...> >;
 
         template<typename C, typename ...Is>
         using IndirectPredicate = meta::and_<
             meta::fast_and<Readable<Is>...>,
             meta::lazy::apply<
-                meta::quote<detail::indirect_apply_combine>,
-                meta::quote<meta::fast_and>,
-                meta::bind_front<meta::quote<Predicate>, C>,
+                detail::iter_map_reduce_fn_<
+                    meta::quote<meta::fast_and>,
+                    meta::bind_front<meta::quote<Predicate>, C>>,
                 Is...>>;
 
         template<typename C, typename I0, typename I1 = I0>
         using IndirectRelation = meta::and_<
             meta::fast_and<Readable<I0>, Readable<I1>>,
             meta::lazy::apply<
-                meta::quote<detail::indirect_apply_combine>,
-                meta::quote<meta::fast_and>,
-                meta::bind_front<meta::quote<Relation>, C>,
+                detail::iter_map_reduce_fn_<
+                    meta::quote<meta::fast_and>,
+                    meta::bind_front<meta::quote<Relation>, C>>,
                 I0, I1>>;
 
         template<typename C, typename ...Is>

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -434,39 +434,6 @@ namespace ranges
 
         namespace detail
         {
-            template<typename I, typename Proj>
-            struct projected_readable
-            {
-                using value_type =
-                    decay_t<concepts::Callable::result_t<Proj, concepts::Readable::value_t<I>>>;
-                using reference =
-                    concepts::Callable::result_t<Proj, concepts::Readable::reference_t<I>>;
-                reference operator*() const;
-            };
-
-            template<typename I, typename Proj>
-            struct Projectable_
-            {
-                using type =
-                    meta::fast_and<
-                        Callable<Proj, concepts::Readable::value_t<I>>,
-                        Callable<Proj, concepts::Readable::reference_t<I>>,
-                        Callable<Proj, concepts::Readable::rvalue_reference_t<I>>>;
-            };
-        }
-
-        ////////////////////////////////////////////////////////////////////////////////////////////
-        // Composite concepts for use defining algorithms:
-        template<typename I, typename Proj>
-        using Projectable = meta::and_<
-            Readable<I>,
-            detail::Projectable_<I, Proj>>;
-
-        template<typename I, typename Proj>
-        using Project = meta::if_<Projectable<I, Proj>, detail::projected_readable<I, Proj>>;
-
-        namespace detail
-        {
             // Return the value and reference types of an iterator in a list.
             template<typename I>
             using readable_types_ =
@@ -482,7 +449,7 @@ namespace ranges
                         meta::transform<meta::list<Is...>, meta::quote<readable_types_>>>,
                     meta::list<concepts::Readable::common_reference_t<Is>...>>;
 
-            template<typename ReduceFn, typename MapFn>
+            template<typename MapFn, typename ReduceFn>
             using iter_map_reduce_fn_ =
                 meta::compose<
                     meta::uncurry<meta::on<ReduceFn, meta::uncurry<MapFn>>>,
@@ -495,16 +462,16 @@ namespace ranges
             // C must be callable with the values and references read from the Is.
             meta::lazy::apply<
                 detail::iter_map_reduce_fn_<
-                    meta::quote<meta::fast_and>,
-                    meta::bind_front<meta::quote<Function>, C>>,
+                    meta::bind_front<meta::quote<Function>, C>,
+                    meta::quote<meta::fast_and>>,
                 Is...>,
             // In addition, the return types of the C invocations tried above must all
             // share a common reference type. (The lazy::apply is so that this doesn't get
             // evaluated unless C is truly callable as determined above.)
             meta::lazy::apply<
                 detail::iter_map_reduce_fn_<
-                    meta::quote<CommonReference>,
-                    meta::bind_front<meta::quote<concepts::Function::result_t>, C>>,
+                    meta::bind_front<meta::quote<concepts::Function::result_t>, C>,
+                    meta::quote<CommonReference>>,
                 Is...> >;
 
         template<typename C, typename ...Is>
@@ -512,8 +479,8 @@ namespace ranges
             meta::fast_and<Readable<Is>...>,
             meta::lazy::apply<
                 detail::iter_map_reduce_fn_<
-                    meta::quote<meta::fast_and>,
-                    meta::bind_front<meta::quote<Predicate>, C>>,
+                    meta::bind_front<meta::quote<Predicate>, C>,
+                    meta::quote<meta::fast_and>>,
                 Is...>>;
 
         template<typename C, typename I0, typename I1 = I0>
@@ -521,8 +488,8 @@ namespace ranges
             meta::fast_and<Readable<I0>, Readable<I1>>,
             meta::lazy::apply<
                 detail::iter_map_reduce_fn_<
-                    meta::quote<meta::fast_and>,
-                    meta::bind_front<meta::quote<Relation>, C>>,
+                    meta::bind_front<meta::quote<Relation>, C>,
+                    meta::quote<meta::fast_and>>,
                 I0, I1>>;
 
         template<typename C, typename ...Is>
@@ -534,6 +501,26 @@ namespace ranges
         template<typename C, typename I0, typename I1 = I0>
         using IndirectCallableRelation = IndirectRelation<function_type<C>, I0, I1>;
 
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // Project struct, for "projecting" a Readable with a unary callable
+        namespace detail
+        {
+            template<typename I, typename Proj>
+            struct projected_readable
+            {
+                using value_type =
+                    decay_t<concepts::Callable::result_t<Proj, concepts::Readable::value_t<I>>>;
+                using reference =
+                    concepts::Callable::result_t<Proj, concepts::Readable::reference_t<I>>;
+                reference operator*() const;
+            };
+        }
+
+        template<typename I, typename Proj>
+        using Projected = meta::if_<IndirectCallable<Proj, I>, detail::projected_readable<I, Proj>>;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // Composite concepts for use defining algorithms:
         template<typename I, typename V = concepts::Readable::value_t<I>>
         using Permutable = meta::fast_and<
             ForwardIterator<I>,
@@ -546,7 +533,7 @@ namespace ranges
             InputIterator<I0>,
             InputIterator<I1>,
             WeaklyIncrementable<Out>,
-            IndirectCallableRelation<C, Project<I0, P0>, Project<I1, P1>>,
+            IndirectCallableRelation<C, Projected<I0, P0>, Projected<I1, P1>>,
             IndirectlyCopyable<I0, Out>,
             IndirectlyCopyable<I1, Out>>;
 
@@ -556,27 +543,27 @@ namespace ranges
             InputIterator<I0>,
             InputIterator<I1>,
             WeaklyIncrementable<Out>,
-            IndirectCallableRelation<C, Project<I0, P0>, Project<I1, P1>>,
+            IndirectCallableRelation<C, Projected<I0, P0>, Projected<I1, P1>>,
             IndirectlyMovable<I0, Out>,
             IndirectlyMovable<I1, Out>>;
 
         template<typename I, typename C = ordered_less, typename P = ident>
         using Sortable = meta::fast_and<
             ForwardIterator<I>,
-            IndirectCallableRelation<C, Project<I, P>, Project<I, P>>,
+            IndirectCallableRelation<C, Projected<I, P>, Projected<I, P>>,
             Permutable<I>>;
 
         template<typename I, typename V2, typename C = ordered_less, typename P = ident>
         using BinarySearchable = meta::fast_and<
             ForwardIterator<I>,
-            IndirectCallableRelation<C, Project<I, P>, V2 const *>>;
+            IndirectCallableRelation<C, Projected<I, P>, V2 const *>>;
 
         template<typename I1, typename I2, typename C = equal_to, typename P1 = ident,
             typename P2 = ident>
         using WeaklyAsymmetricallyComparable = meta::fast_and<
             InputIterator<I1>,
             WeakInputIterator<I2>,
-            IndirectCallablePredicate<C, Project<I1, P1>, Project<I2, P2>>>;
+            IndirectCallablePredicate<C, Projected<I1, P1>, Projected<I2, P2>>>;
 
         template<typename I1, typename I2, typename C = equal_to, typename P1 = ident,
             typename P2 = ident>
@@ -588,7 +575,7 @@ namespace ranges
             typename P2 = ident>
         using WeaklyComparable = meta::fast_and<
             WeaklyAsymmetricallyComparable<I1, I2, C, P1, P2>,
-            IndirectCallableRelation<C, Project<I1, P1>, Project<I2, P2>>>;
+            IndirectCallableRelation<C, Projected<I1, P1>, Projected<I2, P2>>>;
 
         template<typename I1, typename I2, typename C = equal_to, typename P1 = ident,
             typename P2 = ident>

--- a/include/range/v3/utility/iterator_concepts.hpp
+++ b/include/range/v3/utility/iterator_concepts.hpp
@@ -503,6 +503,7 @@ namespace ranges
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Project struct, for "projecting" a Readable with a unary callable
+        /// \cond
         namespace detail
         {
             template<typename I, typename Proj>
@@ -515,6 +516,7 @@ namespace ranges
                 reference operator*() const;
             };
         }
+        /// \endcond
 
         template<typename I, typename Proj>
         using Projected = meta::if_<IndirectCallable<Proj, I>, detail::projected_readable<I, Proj>>;
@@ -610,14 +612,11 @@ namespace ranges
             };
 
             struct SizedIteratorRange
-              : refines<IteratorRange>
+              : refines<SizedIteratorRangeLike_>
             {
                 template<typename I, typename S,
                     meta::if_<std::is_same<I, S>, int> = 0>
-                auto requires_(I&& i, I&& s) -> decltype(
-                    concepts::valid_expr(
-                        concepts::model_of<Integral>(s - i)
-                    ));
+                auto requires_(I&& i, I&& s) -> void;
 
                 template<typename I, typename S,
                     meta::if_c<!std::is_same<I, S>::value, int> = 0,
@@ -626,9 +625,7 @@ namespace ranges
                     concepts::valid_expr(
                         concepts::model_of<SizedIteratorRange, I, I>(),
                         concepts::model_of<Common, I, S>(),
-                        concepts::model_of<SizedIteratorRange, C, C>(),
-                        concepts::model_of<Integral>(s - i),
-                        concepts::same_type(s - i, i - s)
+                        concepts::model_of<SizedIteratorRange, C, C>()
                     ));
             };
         }

--- a/include/range/v3/utility/move.hpp
+++ b/include/range/v3/utility/move.hpp
@@ -69,8 +69,7 @@ namespace ranges
             void indirect_move();
 
             // Default indirect_move overload.
-            template<typename I,
-                typename R = decltype(*std::declval<I const &>())>
+            template<typename I, typename R = reference_t<I const>>
             auto indirect_move(I const &i)
             RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
             (

--- a/include/range/v3/utility/optional.hpp
+++ b/include/range/v3/utility/optional.hpp
@@ -34,11 +34,11 @@ namespace ranges
         struct optional
         {
         private:
-            tagged_variant<meta::nil_, T> data_;
+            variant<meta::nil_, T> data_;
         public:
             optional() = default;
             optional(T t)
-              : data_(meta::size_t<1>{}, std::move(t))
+              : data_(emplaced_index<1>, std::move(t))
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
             template <typename...Args, CONCEPT_REQUIRES_(Constructible<T, Args...>::value)>
@@ -46,7 +46,7 @@ namespace ranges
             template <typename...Args, CONCEPT_REQUIRES_(Constructible<T, Args...>())>
 #endif
             explicit optional(in_place_t, Args &&...args)
-              : data_(meta::size_t<1>{}, std::forward<Args>(args)...)
+              : data_(emplaced_index<1>, std::forward<Args>(args)...)
             {}
             explicit operator bool() const
             {
@@ -64,17 +64,17 @@ namespace ranges
             }
             optional &operator=(T const &t)
             {
-                ranges::set<1>(data_, t);
+                ranges::emplace<1>(data_, t);
                 return *this;
             }
             optional &operator=(T &&t)
             {
-                ranges::set<1>(data_, std::move(t));
+                ranges::emplace<1>(data_, std::move(t));
                 return *this;
             }
             void reset()
             {
-                ranges::set<0>(data_);
+                ranges::emplace<0>(data_);
             }
         };
     }

--- a/include/range/v3/utility/optional.hpp
+++ b/include/range/v3/utility/optional.hpp
@@ -16,6 +16,7 @@
 
 #include <meta/meta.hpp>
 #include <range/v3/range_fwd.hpp>
+#include <range/v3/utility/static_const.hpp>
 #include <range/v3/utility/variant.hpp>
 
 namespace ranges
@@ -23,6 +24,12 @@ namespace ranges
     inline namespace v3
     {
         /// \ingroup group-utility
+        struct in_place_t {};
+        namespace
+        {
+            constexpr auto &in_place = static_const<in_place_t>::value;
+        }
+
         template<typename T>
         struct optional
         {
@@ -32,6 +39,14 @@ namespace ranges
             optional() = default;
             optional(T t)
               : data_(meta::size_t<1>{}, std::move(t))
+            {}
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+            template <typename...Args, CONCEPT_REQUIRES_(Constructible<T, Args...>::value)>
+#else
+            template <typename...Args, CONCEPT_REQUIRES_(Constructible<T, Args...>())>
+#endif
+            explicit optional(in_place_t, Args &&...args)
+              : data_(meta::size_t<1>{}, std::forward<Args>(args)...)
             {}
             explicit operator bool() const
             {

--- a/include/range/v3/utility/semiregular.hpp
+++ b/include/range/v3/utility/semiregular.hpp
@@ -36,6 +36,10 @@ namespace ranges
             semiregular(T f)
               : t_(std::move(f))
             {}
+            template<typename ...Args>
+            semiregular(in_place_t, Args &&...args)
+              : t_(in_place, std::forward<Args>(args)...)
+            {}
             T & get()
             {
                 RANGES_ASSERT(!!t_);

--- a/include/range/v3/utility/swap.hpp
+++ b/include/range/v3/utility/swap.hpp
@@ -152,18 +152,18 @@ namespace ranges
             template<typename Readable0, typename Readable1>
             RANGES_CXX14_CONSTEXPR
             meta::if_c<
-                is_swappable<decltype(*std::declval<Readable0>()),
-                             decltype(*std::declval<Readable1>())>::value>
+                is_swappable<decltype(*std::declval<Readable0 &>()),
+                             decltype(*std::declval<Readable1 &>())>::value>
             indirect_swap(Readable0 a, Readable1 b)
-                noexcept(is_nothrow_swappable<decltype(*std::declval<Readable0>()),
-                                              decltype(*std::declval<Readable1>())>::value);
+                noexcept(is_nothrow_swappable<decltype(*std::declval<Readable0 &>()),
+                                              decltype(*std::declval<Readable1 &>())>::value);
 
             template<typename Readable0, typename Readable1>
             RANGES_CXX14_CONSTEXPR
             meta::if_c<
                 !is_swappable<
-                    decltype(*std::declval<Readable0>()),
-                    decltype(*std::declval<Readable1>())>::value &&
+                    decltype(*std::declval<Readable0 &>()),
+                    decltype(*std::declval<Readable1 &>())>::value &&
                 is_indirectly_movable<Readable0, Readable1>::value &&
                 is_indirectly_movable<Readable1, Readable0>::value>
             indirect_swap(Readable0 a, Readable1 b)
@@ -214,11 +214,11 @@ namespace ranges
             template<typename Readable0, typename Readable1>
             RANGES_CXX14_CONSTEXPR
             meta::if_c<
-                is_swappable<decltype(*std::declval<Readable0>()),
-                             decltype(*std::declval<Readable1>())>::value>
+                is_swappable<decltype(*std::declval<Readable0 &>()),
+                             decltype(*std::declval<Readable1 &>())>::value>
             indirect_swap(Readable0 a, Readable1 b)
-                noexcept(is_nothrow_swappable<decltype(*std::declval<Readable0>()),
-                                              decltype(*std::declval<Readable1>())>::value)
+                noexcept(is_nothrow_swappable<decltype(*std::declval<Readable0 &>()),
+                                              decltype(*std::declval<Readable1 &>())>::value)
             {
                 swap(*a, *b);
             }
@@ -227,8 +227,8 @@ namespace ranges
             RANGES_CXX14_CONSTEXPR
             meta::if_c<
                 !is_swappable<
-                    decltype(*std::declval<Readable0>()),
-                    decltype(*std::declval<Readable1>())>::value &&
+                    decltype(*std::declval<Readable0 &>()),
+                    decltype(*std::declval<Readable1 &>())>::value &&
                 is_indirectly_movable<Readable0, Readable1>::value &&
                 is_indirectly_movable<Readable1, Readable0>::value>
             indirect_swap(Readable0 a, Readable1 b)

--- a/include/range/v3/utility/variant.hpp
+++ b/include/range/v3/utility/variant.hpp
@@ -37,27 +37,66 @@ namespace ranges
         }
         /// \endcond
 
+        template<std::size_t I>
+        struct emplaced_index_t;
+
         template<typename...Ts>
-        struct tagged_variant;
+        struct variant;
 
         template<std::size_t N, typename Var>
-        struct tagged_variant_element;
+        struct variant_element;
 
         template<std::size_t N, typename Var>
-        using tagged_variant_element_t =
-            meta::_t<tagged_variant_element<N, Var>>;
+        using variant_element_t =
+            meta::_t<variant_element<N, Var>>;
+
+        template<std::size_t I>
+        struct emplaced_index_t
+          : meta::size_t<I>
+        {};
+
+        /// \cond
+    #if !RANGES_CXX_VARIABLE_TEMPLATES
+        template<std::size_t I>
+        inline emplaced_index_t<I> emplaced_index()
+        {
+            return {};
+        }
+        template<std::size_t I>
+        using _emplaced_index_t_ = emplaced_index_t<I>(&)();
+    #define RANGES_EMPLACED_INDEX_T(I) _emplaced_index_t_<I>
+    #else
+        /// \endcond
+        namespace
+        {
+            template<std::size_t I>
+#ifdef RANGES_WORKAROUND_MSVC_AUTO_VARIABLE_TEMPLATE
+            constexpr const emplaced_index_t<I> &emplaced_index = static_const<emplaced_index_t<I>>::value;
+#else
+            constexpr auto &emplaced_index = static_const<emplaced_index_t<I>>::value;
+#endif
+        }
+        /// \cond
+    #define RANGES_EMPLACED_INDEX_T(I) emplaced_index_t<I>
+    #endif
+        /// \endcond
 
         /// \cond
         namespace detail
         {
             template<typename Fun, typename T, std::size_t N,
-                typename = decltype(std::declval<Fun>()(std::declval<T &>(), meta::size_t<N>{}))>
-            void apply_if(Fun &&fun, T &t, meta::size_t<N> u)
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+                CONCEPT_REQUIRES_(Function<Fun, T &, meta::size_t<N>>::value)>
+#else
+                CONCEPT_REQUIRES_(Function<Fun, T &, meta::size_t<N>>())>
+#endif
+            void apply_if(Fun fun, T &t, meta::size_t<N> u)
             {
-                std::forward<Fun>(fun)(t, u);
+                fun(t, u);
             }
 
-            [[noreturn]] inline void apply_if(any, any, any)
+            template<class T>
+            [[noreturn]] inline void apply_if(T, any, any)
             {
                 RANGES_ENSURE(false);
             }
@@ -68,11 +107,11 @@ namespace ranges
             template<>
             union variant_data<>
             {
-                template <typename That,
+                template<typename That,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                     CONCEPT_REQUIRES_(Same<variant_data, uncvref_t<That>>::value)>
 #else
-                    CONCEPT_REQUIRES_(Same<variant_data,uncvref_t<That>>())>
+                    CONCEPT_REQUIRES_(Same<variant_data, uncvref_t<That>>())>
 #endif
                 [[noreturn]] void move_copy_construct(std::size_t, That &&) const
                 {
@@ -83,8 +122,7 @@ namespace ranges
                     RANGES_ENSURE(false);
                 }
                 template<typename Fun, std::size_t N = 0>
-                [[noreturn]]
-                void apply(std::size_t, Fun &&, meta::size_t<N> = meta::size_t<N>{}) const
+                [[noreturn]] void apply(std::size_t, Fun &&, meta::size_t<N> = meta::size_t<N>{}) const
                 {
                     RANGES_ENSURE(false);
                 }
@@ -103,24 +141,23 @@ namespace ranges
                 tail_t tail;
 
                 template<typename This, typename Fun, std::size_t N>
-                static void apply_(This &this_, std::size_t n, Fun &&fun, meta::size_t<N> u)
+                static void apply_(This &this_, std::size_t n, Fun fun, meta::size_t<N> u)
                 {
                     if(0 == n)
-                        detail::apply_if(detail::forward<Fun>(fun), this_.head, u);
+                        detail::apply_if(detail::move(fun), this_.head, u);
                     else
-                        this_.tail.apply(n - 1, detail::forward<Fun>(fun), meta::size_t<N + 1>{});
+                        this_.tail.apply(n - 1, detail::move(fun), meta::size_t<N + 1>{});
                 }
             public:
-                variant_data()
-                {}
+                variant_data() {}
                 template<typename ...Args,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                     CONCEPT_REQUIRES_(Constructible<head_t, Args...>::value)>
 #else
                     CONCEPT_REQUIRES_(Constructible<head_t, Args...>())>
 #endif
-                variant_data(meta::size_t<0>, Args && ...args)
-                  : head(std::forward<Args>(args)...)
+                constexpr variant_data(meta::size_t<0>, Args && ...args)
+                  : head(detail::forward<Args>(args)...)
                 {}
                 template<std::size_t N, typename ...Args,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
@@ -128,12 +165,12 @@ namespace ranges
 #else
                     CONCEPT_REQUIRES_(0 != N && Constructible<tail_t, meta::size_t<N - 1>, Args...>())>
 #endif
-                variant_data(meta::size_t<N>, Args && ...args)
-                  : tail{meta::size_t<N - 1>{}, std::forward<Args>(args)...}
+                constexpr variant_data(meta::size_t<N>, Args && ...args)
+                  : tail{meta::size_t<N - 1>{}, detail::forward<Args>(args)...}
                 {}
                 ~variant_data()
                 {}
-                template <typename That,
+                template<typename That,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
                     CONCEPT_REQUIRES_(Same<variant_data, decay_t<That>>::value)>
 #else
@@ -155,35 +192,43 @@ namespace ranges
                         return tail.equal(n - 1, that.tail);
                 }
                 template<typename Fun, std::size_t N = 0>
-                void apply(std::size_t n, Fun &&fun, meta::size_t<N> u = {})
+                void apply(std::size_t n, Fun fun, meta::size_t<N> u = {})
                 {
-                    variant_data::apply_(*this, n, std::forward<Fun>(fun), u);
+                    variant_data::apply_(*this, n, detail::move(fun), u);
                 }
                 template<typename Fun, std::size_t N = 0>
-                void apply(std::size_t n, Fun &&fun, meta::size_t<N> u = {}) const
+                void apply(std::size_t n, Fun fun, meta::size_t<N> u = {}) const
                 {
-                    variant_data::apply_(*this, n, std::forward<Fun>(fun), u);
+                    variant_data::apply_(*this, n, detail::move(fun), u);
                 }
             };
+
+            struct empty_variant_tag { };
 
             struct variant_core_access
             {
                 template<typename...Ts>
-                static variant_data<Ts...> &data(tagged_variant<Ts...> &var)
+                static variant_data<Ts...> &data(variant<Ts...> &var)
                 {
                     return var.data_;
                 }
 
                 template<typename...Ts>
-                static variant_data<Ts...> const &data(tagged_variant<Ts...> const &var)
+                static variant_data<Ts...> const &data(variant<Ts...> const &var)
                 {
                     return var.data_;
                 }
 
                 template<typename...Ts>
-                static variant_data<Ts...> &&data(tagged_variant<Ts...> &&var)
+                static variant_data<Ts...> &&data(variant<Ts...> &&var)
                 {
                     return std::move(var).data_;
+                }
+
+                template<typename...Ts>
+                static variant<Ts...> make_empty(meta::id<variant<Ts...>>)
+                {
+                    return variant<Ts...>{empty_variant_tag{}};
                 }
             };
 
@@ -198,12 +243,19 @@ namespace ranges
 
             struct assert_otherwise
             {
+#ifdef RANGES_WORKAROUND_MSVC_OPERATOR_ACCESS
+                [[noreturn]] void operator()(any) const
+                {
+                    RANGES_ENSURE(false);
+                }
+#else
                 [[noreturn]] static void assert_false(any) { RANGES_ENSURE(false); }
                 using fun_t = void(*)(any);
                 operator fun_t() const
                 {
                     return &assert_false;
                 }
+#endif
             };
 
             // Is there a less dangerous way?
@@ -233,50 +285,59 @@ namespace ranges
 #else
                     CONCEPT_REQUIRES_(Constructible<U, Ts...>())>
 #endif
-                void operator()(U &u) const
+                void operator()(U &u)
                 {
-                    // HACKHACKHACK: "workaround" the fact that the visitation
-                    // design does not allow for mutable visitors.
-                    auto& hack = const_cast<construct_fun&>(*this);
-                    hack.construct(u, meta::make_index_sequence<sizeof...(Ts)>{});
+                    this->construct(u, meta::make_index_sequence<sizeof...(Ts)>{});
                 }
+#ifdef RANGES_WORKAROUND_MSVC_OPERATOR_ACCESS
+                using assert_otherwise::operator();
+#endif
             };
 
             template<typename T>
             struct get_fun : assert_otherwise
             {
             private:
-                T *&t_;
+                T **t_;
             public:
                 get_fun(T *&t)
-                  : t_(t)
+                  : t_(&t)
                 {}
                 void operator()(T &t) const
                 {
-                    t_ = std::addressof(t);
+                    *t_ = std::addressof(t);
                 }
+#ifdef RANGES_WORKAROUND_MSVC_OPERATOR_ACCESS
+                using assert_otherwise::operator();
+#endif
             };
 
             template<typename Fun, typename Var = std::nullptr_t>
             struct apply_visitor
+              : private function_type<Fun>
             {
             private:
-                Var &var_;
-                Fun fun_;
+                using BaseFun = function_type<Fun>;
+                Var *var_;
+
+                BaseFun &fn() { return *this; }
+                BaseFun const &fn() const { return *this; }
+
                 template<typename T, std::size_t N>
                 void apply_(T &&t, meta::size_t<N> n, std::true_type) const
                 {
-                    fun_(std::forward<T>(t), n);
-                    var_.template set<N>(nullptr);
+                    fn()(std::forward<T>(t), n);
+                    var_->template emplace<N>(nullptr);
                 }
                 template<typename T, std::size_t N>
                 void apply_(T &&t, meta::size_t<N> n, std::false_type) const
                 {
-                    var_.template set<N>(fun_(std::forward<T>(t), n));
+                    var_->template emplace<N>(fn()(std::forward<T>(t), n));
                 }
             public:
-                apply_visitor(Fun &&fun, Var &var)
-                  : var_(var), fun_(std::forward<Fun>(fun))
+                apply_visitor(Fun fun, Var &var)
+                  : BaseFun(as_function(detail::move(fun)))
+                  , var_(std::addressof(var))
                 {}
                 template<typename T, std::size_t N,
                          typename result_t = result_of_t<Fun(T &&, meta::size_t<N>)>>
@@ -289,70 +350,78 @@ namespace ranges
 
             template<typename Fun>
             struct apply_visitor<Fun, std::nullptr_t>
+              : private function_type<Fun>
             {
             private:
-                Fun fun_;
+                using BaseFun = function_type<Fun>;
+
+                BaseFun &fn() { return *this; }
+                BaseFun const &fn() const { return *this; }
             public:
-                apply_visitor(Fun &&fun)
-                  : fun_(std::forward<Fun>(fun))
+                apply_visitor(Fun fun)
+                  : BaseFun(as_function(detail::move(fun)))
                 {}
                 template<typename T, std::size_t N>
                 auto operator()(T &&t, meta::size_t<N> n) const
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
-                    fun_(std::forward<T>(t), n), void()
+                    this->fn()(std::forward<T>(t), n), void()
                 )
             };
 
             template<typename Fun>
             struct ignore2nd
+              : private function_type<Fun>
             {
             private:
-                Fun fun_;
+                using BaseFun = function_type<Fun>;
+
+                BaseFun &fn() { return *this; }
+                BaseFun const &fn() const { return *this; }
             public:
                 ignore2nd(Fun &&fun)
-                  : fun_(std::forward<Fun>(fun))
+                  : BaseFun(as_function(detail::move(fun)))
                 {}
                 template<typename T, typename U>
-                auto operator()(T &&t, U &&) const ->
-                    decltype(fun_(std::forward<T>(t)))
-                {
-                    return fun_(std::forward<T>(t));
-                }
+                auto operator()(T &&t, U &&) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    this->fn()(std::forward<T>(t))
+                )
             };
 
             template<typename Fun>
-            apply_visitor<ignore2nd<Fun>> make_unary_visitor(Fun &&fun)
+            apply_visitor<ignore2nd<Fun>> make_unary_visitor(Fun fun)
             {
-                return {std::forward<Fun>(fun)};
+                return {detail::move(fun)};
             }
             template<typename Fun, typename Var>
-            apply_visitor<ignore2nd<Fun>, Var> make_unary_visitor(Fun &&fun, Var &var)
+            apply_visitor<ignore2nd<Fun>, Var> make_unary_visitor(Fun fun, Var &var)
             {
-                return{std::forward<Fun>(fun), var};
+                return {detail::move(fun), var};
             }
             template<typename Fun>
-            apply_visitor<Fun> make_binary_visitor(Fun &&fun)
+            apply_visitor<Fun> make_binary_visitor(Fun fun)
             {
-                return{std::forward<Fun>(fun)};
+                return {detail::move(fun)};
             }
             template<typename Fun, typename Var>
-            apply_visitor<Fun, Var> make_binary_visitor(Fun &&fun, Var &var)
+            apply_visitor<Fun, Var> make_binary_visitor(Fun fun, Var &var)
             {
-                return{std::forward<Fun>(fun), var};
+                return {detail::move(fun), var};
             }
 
             template<typename To, typename From>
             struct unique_visitor;
 
             template<typename ...To, typename ...From>
-            struct unique_visitor<tagged_variant<To...>, tagged_variant<From...>>
+            struct unique_visitor<variant<To...>, variant<From...>>
             {
             private:
-                tagged_variant<To...> &var_;
+                variant<To...> *var_;
             public:
-                unique_visitor(tagged_variant<To...> &var)
-                  : var_(var)
+                unique_visitor(variant<To...> &var)
+                  : var_(&var)
                 {}
                 template<typename T, std::size_t N>
                 void operator()(T &&t, meta::size_t<N>) const
@@ -360,14 +429,14 @@ namespace ranges
                     using E = meta::at_c<meta::list<From...>, N>;
                     using F = meta::find<meta::list<To...>, E>;
                     static constexpr std::size_t M = sizeof...(To) - F::size();
-                    var_.template set<M>(std::forward<T>(t));
+                    var_->template emplace<M>(std::forward<T>(t));
                 }
             };
 
             template<typename Fun, typename Types>
             using variant_result_t =
                 meta::apply_list<
-                    meta::quote<tagged_variant>,
+                    meta::quote<variant>,
                     meta::replace<
                         meta::transform<
                             Types,
@@ -378,7 +447,7 @@ namespace ranges
             template<typename Fun, typename Types>
             using variant_result_i_t =
                 meta::apply_list<
-                    meta::quote<tagged_variant>,
+                    meta::quote<variant>,
                     meta::replace<
                         meta::transform<
                             Types,
@@ -388,29 +457,34 @@ namespace ranges
                             meta::as_list<meta::make_index_sequence<Types::size()>>,
 #endif
                             meta::bind_front<meta::quote<concepts::Function::result_t>, Fun>>,
-                        void, std::nullptr_t>>;
+                        void,
+                        std::nullptr_t>>;
 
             template<typename Fun>
             struct unwrap_ref_fun
+              : private function_type<Fun>
             {
             private:
-                Fun fun_;
+                using BaseFun = function_type<Fun>;
+
+                BaseFun &fn() { return *this; }
+                BaseFun const &fn() const { return *this; }
             public:
-                unwrap_ref_fun(Fun &&fun)
-                  : fun_(std::forward<Fun>(fun))
+                unwrap_ref_fun(Fun fun)
+                  : BaseFun(as_function(detail::move(fun)))
                 {}
                 template<typename T>
-                auto operator()(T &&t) const ->
-                    decltype(fun_(unwrap_reference(std::forward<T>(t))))
-                {
-                    return fun_(unwrap_reference(std::forward<T>(t)));
-                }
+                auto operator()(T &&t) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    this->fn()(unwrap_reference(std::forward<T>(t)))
+                )
                 template<typename T, std::size_t N>
-                auto operator()(T &&t, meta::size_t<N> n) const ->
-                    decltype(fun_(unwrap_reference(std::forward<T>(t)), n))
-                {
-                    return fun_(unwrap_reference(std::forward<T>(t)), n);
-                }
+                auto operator()(T &&t, meta::size_t<N> n) const
+                RANGES_DECLTYPE_AUTO_RETURN
+                (
+                    this->fn()(unwrap_reference(std::forward<T>(t)), n)
+                )
             };
         }
         /// \endcond
@@ -418,7 +492,7 @@ namespace ranges
         /// \addtogroup group-utility
         /// @{
         template<typename ...Ts>
-        struct tagged_variant
+        struct variant
         {
         private:
             friend struct detail::variant_core_access;
@@ -436,11 +510,11 @@ namespace ranges
                 }
             }
 
-            template <typename That,
+            template<typename That,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(Same<tagged_variant, detail::decay_t<That>>::value)>
+                CONCEPT_REQUIRES_(Same<variant, detail::decay_t<That>>::value)>
 #else
-                CONCEPT_REQUIRES_(Same<tagged_variant, detail::decay_t<That>>())>
+                CONCEPT_REQUIRES_(Same<variant, detail::decay_t<That>>())>
 #endif
             void assign_(That &&that)
             {
@@ -451,27 +525,22 @@ namespace ranges
                 }
             }
 
-            struct empty_tag { };
-            tagged_variant(empty_tag)
+            constexpr variant(detail::empty_variant_tag)
               : which_((std::size_t)-1)
             {}
 
         public:
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-            CONCEPT_REQUIRES(!Constructible<data_t, meta::size_t<0>>::value)
-#else
-            CONCEPT_REQUIRES(!Constructible<data_t, meta::size_t<0>>())
-#endif
-            tagged_variant()
-              : tagged_variant{empty_tag{}}
-            {}
-#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
             CONCEPT_REQUIRES(Constructible<data_t, meta::size_t<0>>::value)
 #else
             CONCEPT_REQUIRES(Constructible<data_t, meta::size_t<0>>())
 #endif
-            tagged_variant()
-              : tagged_variant{meta::size_t<0>{}}
+            constexpr variant()
+#ifdef RANGES_WORKAROUND_MSVC_194815
+              : which_(0), data_{meta::size_t<0>{}}
+#else
+              : variant{emplaced_index<0>}
+#endif
             {}
             template<std::size_t N, typename...Args,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
@@ -479,36 +548,36 @@ namespace ranges
 #else
                 CONCEPT_REQUIRES_(Constructible<data_t, meta::size_t<N>, Args...>())>
 #endif
-            tagged_variant(meta::size_t<N> n, Args &&...args)
-              : which_(N), data_{n, detail::forward<Args>(args)...}
+            constexpr variant(RANGES_EMPLACED_INDEX_T(N), Args &&...args)
+              : which_(N), data_{meta::size_t<N>{}, detail::forward<Args>(args)...}
             {
                 static_assert(N < sizeof...(Ts), "");
             }
-            tagged_variant(tagged_variant &&that)
-              : tagged_variant{empty_tag{}}
+            variant(variant &&that)
+              : variant{detail::empty_variant_tag{}}
             {
-                assign_(std::move(that));
+                this->assign_(std::move(that));
             }
-            tagged_variant(tagged_variant const &that)
-              : tagged_variant{empty_tag{}}
+            variant(variant const &that)
+              : variant{detail::empty_variant_tag{}}
             {
-                assign_(that);
+                this->assign_(that);
             }
-            tagged_variant &operator=(tagged_variant &&that)
+            variant &operator=(variant &&that)
             {
-                clear_();
-                assign_(std::move(that));
+                this->clear_();
+                this->assign_(std::move(that));
                 return *this;
             }
-            tagged_variant &operator=(tagged_variant const &that)
+            variant &operator=(variant const &that)
             {
-                clear_();
-                assign_(that);
+                this->clear_();
+                this->assign_(that);
                 return *this;
             }
-            ~tagged_variant()
+            ~variant()
             {
-                clear_();
+                this->clear_();
             }
             static constexpr std::size_t size()
             {
@@ -520,10 +589,11 @@ namespace ranges
 #else
                 CONCEPT_REQUIRES_(Constructible<data_t, meta::size_t<N>, Args...>())>
 #endif
-            void set(Args &&...args)
+            void emplace(Args &&...args)
             {
-                clear_();
-                data_.apply(N, detail::make_unary_visitor(detail::construct_fun<Args&&...>{std::forward<Args>(args)...}));
+                this->clear_();
+                detail::construct_fun<Args&&...> fn{std::forward<Args>(args)...};
+                data_.apply(N, detail::make_unary_visitor(std::ref(fn)));
                 which_ = N;
             }
             bool is_valid() const
@@ -537,10 +607,15 @@ namespace ranges
 
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
             using Args_default = meta::transform<types_t, detail::add_ref_t>;
+            using Args_cdefault = meta::transform<types_t, detail::add_cref_t>;
             template<typename Fun>
             using Result_default = detail::variant_result_t<Fun, Args_default>;
             template<typename Fun>
+            using Result_cdefault = detail::variant_result_t<Fun, Args_cdefault>;
+            template<typename Fun>
             using Result_i_default = detail::variant_result_i_t<Fun, Args_default>;
+            template<typename Fun>
+            using Result_i_cdefault = detail::variant_result_i_t<Fun, Args_cdefault>;
 #endif
 
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
@@ -550,70 +625,90 @@ namespace ranges
             template<typename Fun,
                 typename Args = meta::transform<types_t, detail::add_ref_t>,
                 typename Result = detail::variant_result_t<Fun, Args>>
-            Result apply(Fun &&fun)
+            Result apply(Fun fun)
 #endif
             {
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
-                Result_default<Fun> res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result_default<Fun>>{});
 #else
-                Result res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result>{});
 #endif
-                data_.apply(which_, detail::make_unary_visitor(detail::unwrap_ref_fun<Fun>{std::forward<Fun>(fun)}, res));
+                data_.apply(
+                    which_,
+                    detail::make_unary_visitor(
+                        detail::unwrap_ref_fun<Fun>{detail::move(fun)},
+                        res));
+                RANGES_ASSERT(res.is_valid());
                 return res;
             }
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
             template<typename Fun>
-            Result_default<Fun> apply(Fun &&fun) const
+            Result_cdefault<Fun> apply(Fun fun) const
 #else
             template<typename Fun,
                 typename Args = meta::transform<types_t, detail::add_cref_t>,
-                typename Result = detail::variant_result_t<Fun, Args >>
-            Result apply(Fun &&fun) const
+                typename Result = detail::variant_result_t<Fun, Args>>
+            Result apply(Fun fun) const
 #endif
             {
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
-                Result_default<Fun> res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result_cdefault<Fun>>{});
 #else
-                Result res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result>{});
 #endif
-                data_.apply(which_, detail::make_unary_visitor(detail::unwrap_ref_fun<Fun>{std::forward<Fun>(fun)}, res));
+                data_.apply(
+                    which_,
+                    detail::make_unary_visitor(
+                        detail::unwrap_ref_fun<Fun>{detail::move(fun)},
+                        res));
+                RANGES_ASSERT(res.is_valid());
                 return res;
             }
 
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
             template<typename Fun>
-            Result_i_default<Fun> apply_i(Fun &&fun)
+            Result_i_default<Fun> apply_i(Fun fun)
 #else
             template<typename Fun,
                 typename Args = meta::transform<types_t, detail::add_ref_t>,
                 typename Result = detail::variant_result_i_t<Fun, Args>>
-            Result apply_i(Fun &&fun)
+            Result apply_i(Fun fun)
 #endif
             {
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
-                Result_i_default<Fun> res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result_i_default<Fun>>{});
 #else
-                Result res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result>{});
 #endif
-                data_.apply(which_, detail::make_binary_visitor(detail::unwrap_ref_fun<Fun>{std::forward<Fun>(fun)}, res));
+                data_.apply(
+                    which_,
+                    detail::make_binary_visitor(
+                        detail::unwrap_ref_fun<Fun>{detail::move(fun)},
+                        res));
+                RANGES_ASSERT(res.is_valid());
                 return res;
             }
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
             template<typename Fun>
-            Result_i_default<Fun> apply_i(Fun &&fun) const
+            Result_i_cdefault<Fun> apply_i(Fun fun) const
 #else
             template<typename Fun,
                 typename Args = meta::transform<types_t, detail::add_cref_t>,
                 typename Result = detail::variant_result_i_t<Fun, Args >>
-            Result apply_i(Fun &&fun) const
+            Result apply_i(Fun fun) const
 #endif
             {
 #ifdef RANGES_WORKAROUND_MSVC_DEFAULT_TEMPLATE_ARGUMENT
-                Result_i_default<Fun> res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result_i_cdefault<Fun>>{});
 #else
-                Result res;
+                auto res = detail::variant_core_access::make_empty(meta::id<Result>{});
 #endif
-                data_.apply(which_, detail::make_binary_visitor(detail::unwrap_ref_fun<Fun>{std::forward<Fun>(fun)}, res));
+                data_.apply(
+                    which_,
+                    detail::make_binary_visitor(
+                        detail::unwrap_ref_fun<Fun>{detail::move(fun)},
+                        res));
+                RANGES_ASSERT(res.is_valid());
                 return res;
             }
         };
@@ -624,7 +719,7 @@ namespace ranges
 #else
             CONCEPT_REQUIRES_(meta::and_c<(bool)EqualityComparable<Ts, Us>()...>::value)>
 #endif
-        bool operator==(tagged_variant<Ts...> const &lhs, tagged_variant<Us...> const &rhs)
+        bool operator==(variant<Ts...> const &lhs, variant<Us...> const &rhs)
         {
             RANGES_ASSERT(lhs.is_valid());
             RANGES_ASSERT(rhs.is_valid());
@@ -638,13 +733,13 @@ namespace ranges
 #else
             CONCEPT_REQUIRES_(meta::and_c<(bool)EqualityComparable<Ts, Us>()...>::value)>
 #endif
-        bool operator!=(tagged_variant<Ts...> const &lhs, tagged_variant<Us...> const &rhs)
+        bool operator!=(variant<Ts...> const &lhs, variant<Us...> const &rhs)
         {
             return !(lhs == rhs);
         }
 
         template<std::size_t N, typename...Ts>
-        struct tagged_variant_element<N, tagged_variant<Ts...>>
+        struct variant_element<N, variant<Ts...>>
           : meta::if_<
                 std::is_reference<meta::at_c<meta::list<Ts...>, N>>,
                 meta::id<meta::at_c<meta::list<Ts...>, N>>,
@@ -654,13 +749,13 @@ namespace ranges
         ////////////////////////////////////////////////////////////////////////////////////////////
         // get
         template<std::size_t N, typename...Ts>
-        meta::apply<detail::add_ref_t, tagged_variant_element_t<N, tagged_variant<Ts...>>>
-        get(tagged_variant<Ts...> &var)
+        meta::apply<detail::add_ref_t, variant_element_t<N, variant<Ts...>>>
+        get(variant<Ts...> &var)
         {
             RANGES_ASSERT(N == var.which());
             using elem_t =
                 meta::_t<std::remove_reference<
-                    tagged_variant_element_t<N, tagged_variant<Ts...>>>>;
+                    variant_element_t<N, variant<Ts...>>>>;
             using get_fun = detail::get_fun<elem_t>;
             elem_t *elem = nullptr;
             auto &data = detail::variant_core_access::data(var);
@@ -670,8 +765,8 @@ namespace ranges
         }
 
         template<std::size_t N, typename...Ts>
-        meta::apply<detail::add_cref_t, tagged_variant_element_t<N, tagged_variant<Ts...>>>
-        get(tagged_variant<Ts...> const &var)
+        meta::apply<detail::add_cref_t, variant_element_t<N, variant<Ts...>>>
+        get(variant<Ts...> const &var)
         {
             RANGES_ASSERT(N == var.which());
             using elem_t =
@@ -679,7 +774,7 @@ namespace ranges
                     meta::compose<
                         meta::quote_trait<std::remove_reference>,
                         meta::quote_trait<std::add_const>
-                    >, tagged_variant_element_t<N, tagged_variant<Ts...>>>;
+                    >, variant_element_t<N, variant<Ts...>>>;
             using get_fun = detail::get_fun<elem_t>;
             elem_t *elem = nullptr;
             auto &data = detail::variant_core_access::data(var);
@@ -689,57 +784,59 @@ namespace ranges
         }
 
         template<std::size_t N, typename...Ts>
-        meta::_t<std::add_rvalue_reference<tagged_variant_element_t<N, tagged_variant<Ts...>>>>
-        get(tagged_variant<Ts...> &&var)
+        meta::_t<std::add_rvalue_reference<variant_element_t<N, variant<Ts...>>>>
+        get(variant<Ts...> &&var)
         {
             RANGES_ASSERT(N == var.which());
             using elem_t =
                 meta::_t<std::remove_reference<
-                    tagged_variant_element_t<N, tagged_variant<Ts...>>>>;
+                    variant_element_t<N, variant<Ts...>>>>;
             using get_fun = detail::get_fun<elem_t>;
             elem_t *elem = nullptr;
             auto &data = detail::variant_core_access::data(var);
             data.apply(N, detail::make_unary_visitor(detail::unwrap_ref_fun<get_fun>{get_fun(elem)}));
             RANGES_ASSERT(elem != nullptr);
-            return std::forward<tagged_variant_element_t<N, tagged_variant<Ts...>>>(*elem);
+            return std::forward<variant_element_t<N, variant<Ts...>>>(*elem);
         }
 
         ////////////////////////////////////////////////////////////////////////////////////////////
-        // set
+        // emplace
         template<std::size_t N, typename...Ts, typename...Args>
-        void set(tagged_variant<Ts...> &var, Args &&...args)
+        void emplace(variant<Ts...> &var, Args &&...args)
         {
-            var.template set<N>(std::forward<Args>(args)...);
+            var.template emplace<N>(std::forward<Args>(args)...);
         }
 
         ////////////////////////////////////////////////////////////////////////////////////////////
-        // tagged_variant_unique
+        // variant_unique
         template<typename Var>
-        struct tagged_variant_unique;
+        struct variant_unique
+        {};
 
         template<typename ...Ts>
-        struct tagged_variant_unique<tagged_variant<Ts...>>
+        struct variant_unique<variant<Ts...>>
         {
             using type =
                 meta::apply_list<
-                    meta::quote<tagged_variant>,
+                    meta::quote<variant>,
                     meta::unique<meta::list<Ts...>>>;
         };
 
         template<typename Var>
-        using tagged_variant_unique_t = typename tagged_variant_unique<Var>::type;
+        using variant_unique_t = meta::_t<variant_unique<Var>>;
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // unique_variant
         template<typename...Ts>
-        tagged_variant_unique_t<tagged_variant<Ts...>>
-        unique_variant(tagged_variant<Ts...> const &var)
+        variant_unique_t<variant<Ts...>>
+        unique_variant(variant<Ts...> const &var)
         {
-            using From = tagged_variant<Ts...>;
-            using To = tagged_variant_unique_t<From>;
+            using From = variant<Ts...>;
+            using To = variant_unique_t<From>;
             auto &data = detail::variant_core_access::data(var);
-            To res;
+            auto res = detail::variant_core_access::make_empty(meta::id<To>{});
             data.apply(var.which(), detail::unique_visitor<To, From>{res});
+            RANGES_ASSERT(res.is_valid());
             return res;
         }
         /// @}

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -60,6 +60,7 @@ namespace ranges
                     ranges::advance(it, 1, end);
                 }
                 void prev() = delete;
+                void distance_to() = delete;
             };
             adaptor begin_adaptor() const
             {

--- a/include/range/v3/view/adjacent_remove_if.hpp
+++ b/include/range/v3/view/adjacent_remove_if.hpp
@@ -73,11 +73,7 @@ namespace ranges
         public:
             adjacent_remove_if_view() = default;
             adjacent_remove_if_view(Rng rng, F pred)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : adjacent_remove_if_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<adjacent_remove_if_view>{std::move(rng)}
-#endif
               , pred_(as_function(std::move(pred)))
             {}
         };

--- a/include/range/v3/view/any_view.hpp
+++ b/include/range/v3/view/any_view.hpp
@@ -61,7 +61,7 @@ namespace ranges
             {
                 virtual ~any_cursor_interface() {}
                 virtual any_object const &iter() const = 0;
-                virtual Ref current() const = 0;
+                virtual Ref get() const = 0;
                 virtual bool equal(any_cursor_interface const &) const = 0;
                 virtual void next() = 0;
                 virtual any_cursor_interface *clone_() const = 0;
@@ -125,7 +125,7 @@ namespace ranges
                 {
                     return it_;
                 }
-                Ref current() const
+                Ref get() const
                 {
                     return *it_.get();
                 }
@@ -226,10 +226,10 @@ namespace ranges
                     ptr_.reset(that.ptr_ ? that.ptr_->clone() : nullptr);
                     return *this;
                 }
-                Ref current() const
+                Ref get() const
                 {
                     RANGES_ASSERT(ptr_);
-                    return ptr_->current();
+                    return ptr_->get();
                 }
                 bool equal(any_cursor const &that) const
                 {

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -99,7 +99,7 @@ namespace ranges
             adaptor(range_difference_t<Rng> n, range_sentinel_t<Rng> end)
               : box<offset_t>{0}, n_(n), end_(end)
             {}
-            auto current(range_iterator_t<Rng> it) const ->
+            auto get(range_iterator_t<Rng> it) const ->
                 decltype(view::take(make_range(std::move(it), end_), n_))
             {
                 RANGES_ASSERT(it != end_);
@@ -123,9 +123,11 @@ namespace ranges
                 offset() = 0;
             }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-            CONCEPT_REQUIRES(RandomAccessRange<Rng>::value)
+            CONCEPT_REQUIRES(
+                SizedIteratorRange<range_iterator_t<Rng>, range_iterator_t<Rng>>::value)
 #else
-            CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+            CONCEPT_REQUIRES(
+                SizedIteratorRange<range_iterator_t<Rng>, range_iterator_t<Rng>>())
 #endif
             range_difference_t<Rng> distance_to(range_iterator_t<Rng> const &here,
                 range_iterator_t<Rng> const &there, adaptor const &that) const

--- a/include/range/v3/view/chunk.hpp
+++ b/include/range/v3/view/chunk.hpp
@@ -64,11 +64,7 @@ namespace ranges
         public:
             chunk_view() = default;
             chunk_view(Rng rng, range_difference_t<Rng> n)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : chunk_view::view_adaptor(std::move(rng))
-#else
-              : view_adaptor_t<chunk_view>(std::move(rng))
-#endif
               , n_(n)
             {
                 RANGES_ASSERT(0 < n_);

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -69,11 +69,7 @@ namespace ranges
         public:
             const_view() = default;
             explicit const_view(Rng rng)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : const_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<const_view>{std::move(rng)}
-#endif
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
             CONCEPT_REQUIRES(SizedRange<Rng>::value)

--- a/include/range/v3/view/const.hpp
+++ b/include/range/v3/view/const.hpp
@@ -49,7 +49,7 @@ namespace ranges
             struct adaptor
               : adaptor_base
             {
-                reference_ current(range_iterator_t<Rng> it) const
+                reference_ get(range_iterator_t<Rng> it) const
                 {
                     return *it;
                 }

--- a/include/range/v3/view/counted.hpp
+++ b/include/range/v3/view/counted.hpp
@@ -43,10 +43,6 @@ namespace ranges
             {
                 return {it_, n_};
             }
-            detail::counted_sentinel end_cursor() const
-            {
-                return {};
-            }
         public:
             counted_view() = default;
             counted_view(I it, D n)

--- a/include/range/v3/view/cycle.hpp
+++ b/include/range/v3/view/cycle.hpp
@@ -81,16 +81,17 @@ namespace ranges
                 using constify_if = meta::apply<meta::add_const_if_c<IsConst>, T>;
                 using cycled_view_t = constify_if<cycled_view>;
                 using difference_type_ = range_difference_t<Rng>;
+                using iterator = range_iterator_t<constify_if<Rng>>;
 
                 cycled_view_t *rng_;
-                range_iterator_t<constify_if<Rng>> it_;
+                iterator it_;
 
-                range_iterator_t<constify_if<Rng>> get_end_(std::true_type, bool = false) const
+                iterator get_end_(std::true_type, bool = false) const
                 {
                     return ranges::end(rng_->rng_);
                 }
                 template<bool CanBeEmpty = false>
-                range_iterator_t<constify_if<Rng>> get_end_(std::false_type, meta::bool_<CanBeEmpty> = {}) const
+                iterator get_end_(std::false_type, meta::bool_<CanBeEmpty> = {}) const
                 {
                     auto &end_ = ranges::get<end_tag>(*rng_);
                     RANGES_ASSERT(CanBeEmpty || end_);
@@ -117,7 +118,7 @@ namespace ranges
                 {
                     return false;
                 }
-                auto current() const
+                auto get() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     *it_
@@ -162,9 +163,9 @@ namespace ranges
                     it_ = begin + (off < 0 ? off + d : off);
                 }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>::value)
+                CONCEPT_REQUIRES(SizedIteratorRange<iterator, iterator>::value)
 #else
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+                CONCEPT_REQUIRES(SizedIteratorRange<iterator, iterator>())
 #endif
                 difference_type_ distance_to(cursor const &that) const
                 {

--- a/include/range/v3/view/delimit.hpp
+++ b/include/range/v3/view/delimit.hpp
@@ -60,11 +60,7 @@ namespace ranges
         public:
             delimit_view() = default;
             delimit_view(Rng rng, Val value)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : delimit_view::view_adaptor(std::move(rng))
-#else
-              : view_adaptor_t<delimit_view>{std::move(rng)}
-#endif
               , value_(std::move(value))
             {}
         };

--- a/include/range/v3/view/empty.hpp
+++ b/include/range/v3/view/empty.hpp
@@ -29,7 +29,7 @@ namespace ranges
             friend range_access;
             struct cursor
             {
-                [[noreturn]] T const & current() const
+                [[noreturn]] T const & get() const
                 {
                     RANGES_ENSURE(false);
                 }

--- a/include/range/v3/view/generate.hpp
+++ b/include/range/v3/view/generate.hpp
@@ -55,7 +55,7 @@ namespace ranges
                 {
                     return false;
                 }
-                result_t current() const
+                result_t get() const
                 {
                     return view_->val_;
                 }

--- a/include/range/v3/view/generate_n.hpp
+++ b/include/range/v3/view/generate_n.hpp
@@ -58,7 +58,7 @@ namespace ranges
                 {
                     return 0 == n_;
                 }
-                result_t current() const
+                result_t get() const
                 {
                     return rng_->val_;
                 }

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -70,7 +70,7 @@ namespace ranges
                     }
                 };
                 take_while_view<range<range_iterator_t<Rng>, range_sentinel_t<Rng>>, take_while_pred>
-                current() const
+                get() const
                 {
                     return {{cur_, last_}, {cur_, fun_}};
                 }

--- a/include/range/v3/view/group_by.hpp
+++ b/include/range/v3/view/group_by.hpp
@@ -34,6 +34,10 @@ namespace ranges
 {
     inline namespace v3
     {
+        // TODO group_by could support Input ranges by keeping mutable state in
+        // the range itself. The group_by view would then be mutable-only and
+        // Input.
+
         /// \addtogroup group-views
         /// @{
         template<typename Rng, typename Fun>

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -22,6 +22,7 @@
 #include <range/v3/range_traits.hpp>
 #include <range/v3/begin_end.hpp>
 #include <range/v3/view_adaptor.hpp>
+#include <range/v3/utility/move.hpp>
 #include <range/v3/utility/functional.hpp>
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/view/view.hpp>
@@ -41,12 +42,12 @@ namespace ranges
             struct adaptor
               : adaptor_base
             {
-                auto current(range_iterator_t<Rng> it) const ->
+                auto get(range_iterator_t<Rng> const &it) const ->
                     decltype(**it)
                 {
                     return **it;
                 }
-                auto indirect_move(range_iterator_t<Rng> it) const ->
+                auto indirect_move(range_iterator_t<Rng> const &it) const ->
                     decltype(ranges::indirect_move(*it))
                 {
                     return ranges::indirect_move(*it);

--- a/include/range/v3/view/indirect.hpp
+++ b/include/range/v3/view/indirect.hpp
@@ -64,11 +64,7 @@ namespace ranges
         public:
             indirect_view() = default;
             explicit indirect_view(Rng rng)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : indirect_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<indirect_view>{std::move(rng)}
-#endif
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
             CONCEPT_REQUIRES(SizedRange<Rng>::value)

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -60,7 +60,7 @@ namespace ranges
                 cursor_adaptor(range_value_t<Rng> val, bool at_end)
                   : toggl_(!at_end), val_(std::move(val))
                 {}
-                range_value_t<Rng> current(range_iterator_t<Rng> it) const
+                range_value_t<Rng> get(range_iterator_t<Rng> it) const
                 {
                     return toggl_ ? *it : val_;
                 }
@@ -87,9 +87,11 @@ namespace ranges
                         --it;
                 }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>::value)
+                CONCEPT_REQUIRES(
+                    SizedIteratorRange<range_iterator_t<Rng>, range_iterator_t<Rng>>::value)
 #else
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+                CONCEPT_REQUIRES(
+                    SizedIteratorRange<range_iterator_t<Rng>, range_iterator_t<Rng>>())
 #endif
                 range_difference_t<Rng> distance_to(range_iterator_t<Rng> it,
                     range_iterator_t<Rng> other_it, cursor_adaptor const &other) const

--- a/include/range/v3/view/intersperse.hpp
+++ b/include/range/v3/view/intersperse.hpp
@@ -148,11 +148,7 @@ namespace ranges
         public:
             intersperse_view() = default;
             intersperse_view(Rng rng, range_value_t<Rng> val)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : intersperse_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<intersperse_view>{std::move(rng)}
-#endif
               , val_(std::move(val))
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR

--- a/include/range/v3/view/iota.hpp
+++ b/include/range/v3/view/iota.hpp
@@ -147,7 +147,7 @@ namespace ranges
             iota_difference_t<Val> iota_minus(Val const &v0, Val const &v1)
             {
                 using D = iota_difference_t<Val>;
-                return (D) (v0 - v1);
+                return v0 < v1? - static_cast<D>(v1 - v0) : static_cast<D>(v0 - v1);
             }
         }
         /// \endcond
@@ -168,7 +168,7 @@ namespace ranges
             To to_;
             bool done_ = false;
 
-            From current() const
+            From get() const
             {
                 return from_;
             }
@@ -238,7 +238,7 @@ namespace ranges
             From from_;
             To to_;
 
-            From current() const
+            From get() const
             {
                 return from_;
             }
@@ -305,7 +305,7 @@ namespace ranges
 
             From value_;
 
-            From current() const
+            From get() const
             {
                 return value_;
             }

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -150,11 +150,7 @@ namespace ranges
         public:
             join_view() = default;
             explicit join_view(Rng rng)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : join_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<join_view>{std::move(rng)}
-#endif
               , cur_{}
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
@@ -298,11 +294,7 @@ namespace ranges
         public:
             join_view() = default;
             join_view(Rng rng, ValRng val)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : join_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<join_view>{std::move(rng)}
-#endif
               , cur_{}, val_(std::move(val))
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR

--- a/include/range/v3/view/join.hpp
+++ b/include/range/v3/view/join.hpp
@@ -126,7 +126,7 @@ namespace ranges
                     ++it_;
                     satisfy(it);
                 }
-                auto current(range_iterator_t<Rng> const &) const ->
+                auto get(range_iterator_t<Rng> const &) const ->
                     decltype(*it_)
                 {
                     return *it_;
@@ -266,7 +266,7 @@ namespace ranges
                     toggl_ ? (void)++it_ : (void)++val_it_;
                     satisfy(it);
                 }
-                auto current(range_iterator_t<Rng> const &) const ->
+                auto get(range_iterator_t<Rng> const &) const ->
                     common_reference_t<
                         range_reference_t<range_value_t<Rng>>,
                         range_reference_t<ValRng>>

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -62,11 +62,7 @@ namespace ranges
         public:
             move_view() = default;
             explicit move_view(Rng rng)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : move_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<move_view>{std::move(rng)}
-#endif
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
             CONCEPT_REQUIRES(SizedRange<Rng>::value)

--- a/include/range/v3/view/move.hpp
+++ b/include/range/v3/view/move.hpp
@@ -42,7 +42,7 @@ namespace ranges
             struct adaptor : adaptor_base
             {
                 using value_type = range_value_t<Rng>;
-                range_rvalue_reference_t<Rng> current(range_iterator_t<Rng> it) const
+                range_rvalue_reference_t<Rng> get(range_iterator_t<Rng> it) const
                 {
                     return iter_move(it);
                 }

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -145,11 +145,7 @@ namespace ranges
         public:
             partial_sum_view() = default;
             partial_sum_view(Rng rng, Fun fun)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : partial_sum_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<partial_sum_view>{std::move(rng)}
-#endif
               , fun_(as_function(std::move(fun)))
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR

--- a/include/range/v3/view/partial_sum.hpp
+++ b/include/range/v3/view/partial_sum.hpp
@@ -69,7 +69,7 @@ namespace ranges
                 adaptor(partial_sum_view_t &rng, range_value_t<Rng> sum)
                   : sum_(std::move(sum)), rng_(&rng)
                 {}
-                range_value_t<Rng> current(range_iterator_t<Rng> it) const
+                range_value_t<Rng> get(range_iterator_t<Rng> it) const
                 {
                     return *sum_;
                 }
@@ -169,8 +169,8 @@ namespace ranges
             {
             private:
                 friend view_access;
-                template<typename Fun>
-                static auto bind(partial_sum_fn partial_sum, Fun fun)
+                template<typename Fun = plus>
+                static auto bind(partial_sum_fn partial_sum, Fun fun = {})
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
                     make_pipeable(std::bind(partial_sum, std::placeholders::_1,

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -87,6 +87,7 @@ namespace ranges
                     do --it; while(pred(*it));
                 }
                 void advance() = delete;
+                void distance_to() = delete;
             };
             adaptor begin_adaptor()
             {

--- a/include/range/v3/view/remove_if.hpp
+++ b/include/range/v3/view/remove_if.hpp
@@ -102,42 +102,30 @@ namespace ranges
         public:
             remove_if_view() = default;
             remove_if_view(remove_if_view &&that)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : remove_if_view::view_adaptor(std::move(that))
-#else
-              : view_adaptor_t<remove_if_view>(std::move(that))
-#endif
               , pred_(std::move(that).pred_)
               , begin_{}
             {}
             remove_if_view(remove_if_view const &that)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : remove_if_view::view_adaptor(that)
-#else
-              : view_adaptor_t<remove_if_view>(that)
-#endif
               , pred_(that.pred_)
               , begin_{}
             {}
             remove_if_view(Rng rng, Pred pred)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : remove_if_view::view_adaptor(std::move(rng))
-#else
-              : view_adaptor_t<remove_if_view>{std::move(rng)}
-#endif
               , pred_(as_function(std::move(pred)))
               , begin_{}
             {}
             remove_if_view& operator=(remove_if_view &&that)
             {
-                this->view_adaptor_t<remove_if_view>::operator=(std::move(that));
+                this->remove_if_view::view_adaptor::operator=(std::move(that));
                 pred_ = std::move(that).pred_;
                 begin_.reset();
                 return *this;
             }
             remove_if_view& operator=(remove_if_view const &that)
             {
-                this->view_adaptor_t<remove_if_view>::operator=(that);
+                this->remove_if_view::view_adaptor::operator=(that);
                 pred_ = that.pred_;
                 begin_.reset();
                 return *this;

--- a/include/range/v3/view/repeat.hpp
+++ b/include/range/v3/view/repeat.hpp
@@ -51,7 +51,7 @@ namespace ranges
                 cursor(Val value)
                   : value_(value)
                 {}
-                Val current() const
+                Val get() const
                 {
                     return value_;
                 }

--- a/include/range/v3/view/repeat_n.hpp
+++ b/include/range/v3/view/repeat_n.hpp
@@ -52,7 +52,7 @@ namespace ranges
                 cursor(Val value, std::ptrdiff_t n)
                   : value_(std::move(value)), n_(n)
                 {}
-                Val current() const
+                Val get() const
                 {
                     return value_;
                 }

--- a/include/range/v3/view/replace.hpp
+++ b/include/range/v3/view/replace.hpp
@@ -29,6 +29,7 @@ namespace ranges
 {
     inline namespace v3
     {
+        /// \cond
         namespace detail
         {
             template<typename Val1, typename Val2>
@@ -69,6 +70,7 @@ namespace ranges
                 }
             };
         }
+        /// \endcond
 
         /// \addtogroup group-views
         /// @{

--- a/include/range/v3/view/replace_if.hpp
+++ b/include/range/v3/view/replace_if.hpp
@@ -30,6 +30,7 @@ namespace ranges
 {
     inline namespace v3
     {
+        /// \cond
         namespace detail
         {
             template<typename Pred, typename Val>
@@ -107,6 +108,7 @@ namespace ranges
                 }
             };
         }
+        /// \endcond
 
         /// \addtogroup group-views
         /// @{

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -127,9 +127,11 @@ namespace ranges
                         this->prev(it), ranges::advance(it, -n - 1);
                 }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>::value)
+                CONCEPT_REQUIRES(
+                    SizedIteratorRange<range_iterator_t<Rng>, range_iterator_t<Rng>>::value)
 #else
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+                CONCEPT_REQUIRES(
+                    SizedIteratorRange<range_iterator_t<Rng>, range_iterator_t<Rng>>())
 #endif
                 range_difference_t<Rng>
                 distance_to(range_iterator_t<Rng> const &here, range_iterator_t<Rng> const &there,

--- a/include/range/v3/view/reverse.hpp
+++ b/include/range/v3/view/reverse.hpp
@@ -185,38 +185,26 @@ namespace ranges
         public:
             reverse_view() = default;
             reverse_view(reverse_view &&that)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : reverse_view::view_adaptor(std::move(that))
-#else
-              : view_adaptor_t<reverse_view>{std::move(that)}
-#endif
               , detail::reverse_end_<Rng>{}
             {}
             reverse_view(reverse_view const &that)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : reverse_view::view_adaptor(that)
-#else
-              : view_adaptor_t<reverse_view>{that}
-#endif
               , detail::reverse_end_<Rng>{}
             {}
             explicit reverse_view(Rng rng)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : reverse_view::view_adaptor(std::move(rng))
-#else
-              : view_adaptor_t<reverse_view>{std::move(rng)}
-#endif
               , detail::reverse_end_<Rng>{}
             {}
             reverse_view& operator=(reverse_view &&that)
             {
-                this->view_adaptor_t<reverse_view>::operator=(std::move(that));
+                this->reverse_view::view_adaptor::operator=(std::move(that));
                 this->dirty_(BoundedRange<Rng>{});
                 return *this;
             }
             reverse_view& operator=(reverse_view const &that)
             {
-                this->view_adaptor_t<reverse_view>::operator=(that);
+                this->reverse_view::view_adaptor::operator=(that);
                 this->dirty_(BoundedRange<Rng>{});
                 return *this;
             }

--- a/include/range/v3/view/single.hpp
+++ b/include/range/v3/view/single.hpp
@@ -48,7 +48,7 @@ namespace ranges
                 cursor(Val value)
                   : value_(std::move(value)), done_(false)
                 {}
-                Val current() const
+                Val get() const
                 {
                     return value_;
                 }

--- a/include/range/v3/view/slice.hpp
+++ b/include/range/v3/view/slice.hpp
@@ -96,10 +96,6 @@ namespace ranges
                 {
                     return {get_begin_(), count_};
                 }
-                detail::counted_sentinel end_cursor()
-                {
-                    return {};
-                }
             public:
                 slice_view_() = default;
                 slice_view_(slice_view_ &&that)

--- a/include/range/v3/view/split.hpp
+++ b/include/range/v3/view/split.hpp
@@ -75,7 +75,7 @@ namespace ranges
                 };
                 using reference_ =
                     indirect_view<take_while_view<iota_view<range_iterator_t<Rng>>, search_pred>>;
-                reference_ current() const
+                reference_ get() const
                 {
                     return reference_{{view::iota(cur_), {zero_, cur_, last_, fun_}}};
                 }

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -179,11 +179,7 @@ namespace ranges
         public:
             stride_view() = default;
             stride_view(Rng rng, difference_type_ stride)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : stride_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<stride_view>{std::move(rng)}
-#endif
               , stride_(stride)
             {
                 RANGES_ASSERT(0 < stride_);

--- a/include/range/v3/view/stride.hpp
+++ b/include/range/v3/view/stride.hpp
@@ -120,9 +120,9 @@ namespace ranges
                     RANGES_ASSERT(0 == offset());
                 }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>::value)
+                CONCEPT_REQUIRES(SizedIteratorRange<iterator, iterator>::value)
 #else
-                CONCEPT_REQUIRES(RandomAccessRange<Rng>())
+                CONCEPT_REQUIRES(SizedIteratorRange<iterator, iterator>())
 #endif
                 difference_type_ distance_to(iterator here, iterator there, adaptor const &that) const
                 {

--- a/include/range/v3/view/take_exactly.hpp
+++ b/include/range/v3/view/take_exactly.hpp
@@ -70,10 +70,6 @@ namespace ranges
                 {
                     return {ranges::begin(rng_), n_};
                 }
-                counted_sentinel end_cursor() const
-                {
-                    return {};
-                }
             public:
                 take_exactly_view_() = default;
                 take_exactly_view_(Rng rng, difference_type_ n)

--- a/include/range/v3/view/take_while.hpp
+++ b/include/range/v3/view/take_while.hpp
@@ -76,11 +76,7 @@ namespace ranges
         public:
             iter_take_while_view() = default;
             iter_take_while_view(Rng rng, Pred pred)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : iter_take_while_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<iter_take_while_view>{std::move(rng)}
-#endif
               , pred_(as_function(std::move(pred)))
             {}
         };

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -49,6 +49,19 @@ namespace ranges
                             unknown :
                             infinite;
             }
+
+            // indirect_move is put here instead of in iter_transform2_view::cursor to
+            // work around gcc friend name injection bug.
+            template<typename Cursor>
+            struct transform2_cursor_move
+            {
+                template<typename Sent>
+                friend auto indirect_move(basic_iterator<Cursor, Sent> const &it)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    get_cursor(it).indirect_move_()
+                )
+            };
         }
         /// \endcond
 
@@ -77,7 +90,7 @@ namespace ranges
                 adaptor(fun_ref_ fun)
                   : fun_(std::move(fun))
                 {}
-                auto current(range_iterator_t<Rng> it) const
+                auto get(range_iterator_t<Rng> it) const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     fun_(it)
@@ -182,6 +195,7 @@ namespace ranges
 
             struct sentinel;
             struct cursor
+              : detail::transform2_cursor_move<cursor>
             {
             private:
                 friend sentinel;
@@ -190,12 +204,6 @@ namespace ranges
                 range_iterator_t<Rng1> it1_;
                 range_iterator_t<Rng2> it2_;
 
-                template<typename Sent>
-                friend auto indirect_move(basic_iterator<cursor, Sent> const &it)
-                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-                (
-                    get_cursor(it).fun_(move_tag{}, get_cursor(it).it1_, get_cursor(it).it2_)
-                )
             public:
                 using difference_type = difference_type_;
                 using single_pass = meta::or_c<
@@ -214,7 +222,7 @@ namespace ranges
                 cursor(fun_ref_ fun, range_iterator_t<Rng2> it1, range_iterator_t<Rng2> it2)
                   : fun_(std::move(fun)), it1_(std::move(it1)), it2_(std::move(it2))
                 {}
-                auto current() const
+                auto get() const
                 RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
                 (
                     fun_(it1_, it2_)
@@ -252,9 +260,13 @@ namespace ranges
                     ranges::advance(it2_, n);
                 }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES(RandomAccessRange<Rng1>::value && RandomAccessRange<Rng2>::value)
+                CONCEPT_REQUIRES(
+                    SizedIteratorRange<range_iterator_t<Rng1>, range_iterator_t<Rng1>>::value &&
+                    SizedIteratorRange<range_iterator_t<Rng2>, range_iterator_t<Rng2>>::value)
 #else
-                CONCEPT_REQUIRES(RandomAccessRange<Rng1>() && RandomAccessRange<Rng2>())
+                CONCEPT_REQUIRES(
+                    SizedIteratorRange<range_iterator_t<Rng1>, range_iterator_t<Rng1>>() &&
+                    SizedIteratorRange<range_iterator_t<Rng2>, range_iterator_t<Rng2>>())
 #endif
                 difference_type distance_to(cursor const &that) const
                 {
@@ -263,6 +275,11 @@ namespace ranges
                     difference_type d1 = that.it1_ - it1_, d2 = that.it2_ - it2_;
                     return 0 < d1 ? std::min(d1, d2) : std::max(d1, d2);
                 }
+                auto indirect_move_() const
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    fun_(move_tag{}, it1_, it2_)
+                )
             };
 
             struct sentinel

--- a/include/range/v3/view/transform.hpp
+++ b/include/range/v3/view/transform.hpp
@@ -131,11 +131,7 @@ namespace ranges
         public:
             iter_transform_view() = default;
             iter_transform_view(Rng rng, Fun fun)
-#ifdef RANGES_WORKAROUND_MSVC_207134
               : iter_transform_view::view_adaptor{std::move(rng)}
-#else
-              : view_adaptor_t<iter_transform_view>{std::move(rng)}
-#endif
               , fun_(as_function(std::move(fun)))
             {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR

--- a/include/range/v3/view/view.hpp
+++ b/include/range/v3/view/view.hpp
@@ -27,6 +27,7 @@ namespace ranges
 {
     inline namespace v3
     {
+        /// \cond
         namespace detail
         {
             struct null_pipe
@@ -36,6 +37,7 @@ namespace ranges
                 {}
             };
         }
+        /// \endcond
 
         namespace view
         {
@@ -137,12 +139,12 @@ namespace ranges
                     view_(std::forward<Rng>(rng), std::forward<Rest>(rest)...)
                 )
                 // Currying overload.
-                template<typename T, typename...Rest, typename V = View>
-                auto operator()(T && t, Rest &&... rest) const
+                template<typename...Ts, typename V = View>
+                auto operator()(Ts &&... ts) const
                 RANGES_DECLTYPE_AUTO_RETURN
                 (
-                    make_view(view_access::impl<V>::bind(view_, std::forward<T>(t),
-                        std::forward<Rest>(rest)...))
+                    make_view(view_access::impl<V>::bind(view_,
+                        std::forward<Ts>(ts)...))
                 )
             };
             /// \endcond

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -96,7 +96,7 @@ namespace ranges
             struct adaptor_value_type2<
                 BaseIter,
                 Adapt,
-                meta::void_<decltype(Adapt::current(BaseIter{}, adaptor_base_current_mem_fn{}))>>
+                meta::void_<decltype(Adapt::get(BaseIter{}, adaptor_base_current_mem_fn{}))>>
             {
                 using value_type = iterator_value_t<BaseIter>;
             };
@@ -122,16 +122,8 @@ namespace ranges
         template<typename Derived>
         using view_adaptor_t = meta::_t<range_access::view_adaptor<Derived>>;
 
-#if defined(RANGES_WORKAROUND_MSVC_PERMISSIVE_HIDDEN_FRIEND) || defined(RANGES_WORKAROUND_MSVC_INDIRECT_MOVE)
-        namespace adaptor_cursor_detail
-        {
-#endif
         template<typename BaseIt, typename Adapt>
         struct adaptor_cursor;
-#if defined(RANGES_WORKAROUND_MSVC_PERMISSIVE_HIDDEN_FRIEND) || defined(RANGES_WORKAROUND_MSVC_INDIRECT_MOVE)
-        }
-        using adaptor_cursor_detail::adaptor_cursor;
-#endif
 
         template<typename BaseSent, typename Adapt>
         struct adaptor_sentinel;
@@ -170,7 +162,8 @@ namespace ranges
 #else
             template<typename I, CONCEPT_REQUIRES_(WeakIterator<I>())>
 #endif
-            static iterator_reference_t<I> current(I const &it, detail::adaptor_base_current_mem_fn = {})
+            static iterator_reference_t<I> get(I const &it,
+                detail::adaptor_base_current_mem_fn = {})
                 noexcept(noexcept(iterator_reference_t<I>(*it)))
             {
                 return *it;
@@ -203,9 +196,9 @@ namespace ranges
                 it += n;
             }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-            template<typename I, CONCEPT_REQUIRES_(RandomAccessIterator<I>::value)>
+            template<typename I, CONCEPT_REQUIRES_(SizedIteratorRange<I, I>::value)>
 #else
-            template<typename I, CONCEPT_REQUIRES_(RandomAccessIterator<I>())>
+            template<typename I, CONCEPT_REQUIRES_(SizedIteratorRange<I, I>())>
 #endif
             static iterator_difference_t<I> distance_to(I const &it0, I const &it1)
             {
@@ -222,16 +215,30 @@ namespace ranges
             }
         };
 
-#if defined(RANGES_WORKAROUND_MSVC_PERMISSIVE_HIDDEN_FRIEND) || defined(RANGES_WORKAROUND_MSVC_INDIRECT_MOVE)
-        namespace adaptor_cursor_detail
+        /// \cond
+        namespace detail
         {
-#endif
+            template<typename Cursor>
+            struct adaptor_cursor_move
+            {
+                // Gives users a way to override the default indirect_move function in their adaptors.
+                template<typename Sent>
+                friend auto indirect_move(basic_iterator<Cursor, Sent> const &it)
+                RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
+                (
+                    get_cursor(it).indirect_move_(42)
+                )
+            };
+        }
+        /// \endcond
+
         // Build a cursor out of an iterator into the adapted range, and an
         // adaptor that customizes behavior.
         template<typename BaseIter, typename Adapt>
         struct RANGES_BROKEN_EBO adaptor_cursor
           : private compressed_pair<BaseIter, Adapt>
           , detail::adaptor_value_type<BaseIter, Adapt>
+          , detail::adaptor_cursor_move<adaptor_cursor<BaseIter, Adapt>>
         {
             using single_pass = meta::or_<
                 range_access::single_pass_t<Adapt>,
@@ -239,6 +246,7 @@ namespace ranges
             using compressed_pair<BaseIter, Adapt>::compressed_pair;
             struct mixin : basic_mixin<adaptor_cursor>
             {
+                mixin() = default;
                 using basic_mixin<adaptor_cursor>::basic_mixin;
                 // All iterators into adapted ranges have a base() member for fetching
                 // the underlying iterator.
@@ -276,6 +284,7 @@ namespace ranges
             {
                 return second.distance_to(first, that.first);
             }
+        public:
             // If the adaptor has an indirect_move function, use it.
             template<typename A = Adapt,
                 typename X = decltype(std::declval<A>().indirect_move(first))>
@@ -283,7 +292,7 @@ namespace ranges
                 noexcept(noexcept(std::declval<A>().indirect_move(first)))
             {
                 using V = range_access::cursor_value_t<adaptor_cursor>;
-                using R = decltype(std::declval<A>().current(first));
+                using R = decltype(std::declval<A>().get(first));
                 static_assert(
                     CommonReference<X &&, V const &>(),
                     "In your adaptor, the result of your indirect_move member function does "
@@ -298,7 +307,7 @@ namespace ranges
             // If there is no indirect_move member and the adaptor has not overridden the current
             // member function, then dispatch to the base iterator's indirect_move function.
             template<typename A = Adapt,
-                typename R = decltype(std::declval<A>().current(first, detail::adaptor_base_current_mem_fn{})),
+                typename R = decltype(std::declval<A>().get(first, detail::adaptor_base_current_mem_fn{})),
                 typename X = iterator_rvalue_reference_t<BaseIter>>
             X indirect_move_(long) const
 #ifndef RANGES_WORKAROUND_MSVC_211850
@@ -311,9 +320,8 @@ namespace ranges
             // If the adaptor does not have an indirect_move function but overrides the current
             // member function, apply std::move to the result of calling current.
             template<typename A = Adapt,
-                typename R = decltype(std::declval<A>().current(first)),
-                typename X =
-                    meta::if_<std::is_reference<R>, meta::_t<std::remove_reference<R>> &&, R>>
+                typename R = decltype(std::declval<A>().get(first)),
+                typename X = aux::move_t<R>>
             X indirect_move_(detail::any) const
                 noexcept(noexcept(X(static_cast<X &&>(std::declval<R>()))))
             {
@@ -324,27 +332,19 @@ namespace ranges
                     "share a common reference type with the result of moving the value "
                     "returned by current. Consider defining an indirect_move function "
                     "in your adaptor.");
-                return static_cast<X &&>(second.current(first));
+                return static_cast<X &&>(second.get(first));
             }
-            // Gives users a way to override the default indirect_move function in their adaptors.
-            template<typename Sent>
-            friend auto indirect_move(basic_iterator<adaptor_cursor, Sent> const &it)
-            RANGES_DECLTYPE_AUTO_RETURN_NOEXCEPT
-            (
-                get_cursor(it).indirect_move_(42)
-            )
-        public:
             template<typename A = Adapt,
-                typename R = decltype(std::declval<A>().current(first))>
-            R current() const
-                noexcept(noexcept(R(std::declval<A>().current(first))))
+                typename R = decltype(std::declval<A>().get(first))>
+            R get() const
+                noexcept(noexcept(R(std::declval<A>().get(first))))
             {
                 using V = range_access::cursor_value_t<adaptor_cursor>;
                 static_assert(
                     CommonReference<R &&, V &>(),
                     "In your adaptor, you've specified a value type that does not "
                     "share a common reference type with the return type of current.");
-                return second.current(first);
+                return second.get(first);
             }
             template<typename A = Adapt,
                 typename R = decltype(std::declval<A>().next(first))>
@@ -377,9 +377,6 @@ namespace ranges
                 return this->distance_to_(that, 42);
             }
         };
-#if defined(RANGES_WORKAROUND_MSVC_PERMISSIVE_HIDDEN_FRIEND) || defined(RANGES_WORKAROUND_MSVC_INDIRECT_MOVE)
-        }
-#endif
 
         // Build a sentinel out of a sentinel into the adapted range, and an
         // adaptor that customizes behavior.
@@ -408,6 +405,7 @@ namespace ranges
             struct mixin
               : basic_mixin<adaptor_sentinel>
             {
+                mixin() = default;
                 using basic_mixin<adaptor_sentinel>::basic_mixin;
                 // All iterators into adapted ranges have a base() member for fetching
                 // the underlying iterator.

--- a/include/range/v3/view_adaptor.hpp
+++ b/include/range/v3/view_adaptor.hpp
@@ -119,9 +119,6 @@ namespace ranges
         template<typename Derived>
         using base_range_t = meta::_t<range_access::base_range<Derived>>;
 
-        template<typename Derived>
-        using view_adaptor_t = meta::_t<range_access::view_adaptor<Derived>>;
-
         template<typename BaseIt, typename Adapt>
         struct adaptor_cursor;
 
@@ -443,7 +440,6 @@ namespace ranges
             friend Derived;
             friend range_access;
             friend adaptor_base;
-            using view_adaptor_t = view_adaptor;
             using base_range_t = view::all_t<BaseRng>;
             using view_facade<Derived, Cardinality>::derived;
             // Mutable here. Const-correctness is enforced below by disabling

--- a/include/range/v3/view_facade.hpp
+++ b/include/range/v3/view_facade.hpp
@@ -73,15 +73,6 @@ namespace ranges
 
         /// \addtogroup group-core
         /// @{
-        struct default_sentinel
-        {
-            template<typename Cur>
-            static constexpr bool equal(Cur const &pos)
-            {
-                return range_access::done(pos);
-            }
-        };
-
         template<typename Derived, cardinality Cardinality>
         struct view_facade
           : view_interface<Derived, Cardinality>
@@ -95,7 +86,7 @@ namespace ranges
             {
                 return derived();
             }
-            default_sentinel end_cursor() const
+            default_end_cursor end_cursor() const
             {
                 return {};
             }

--- a/include/range/v3/view_interface.hpp
+++ b/include/range/v3/view_interface.hpp
@@ -99,17 +99,28 @@ namespace ranges
             /// Access the size of the range, if it can be determined:
             template<typename D = Derived,
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-                CONCEPT_REQUIRES_(Same<D, Derived>::value && (Cardinality >= 0 ||
-                    SizedIteratorRange<range_iterator_t<D>, range_sentinel_t<D>>::value))>
+                CONCEPT_REQUIRES_(Same<D, Derived>::value && Cardinality >= 0)>
 #else
-                CONCEPT_REQUIRES_(Same<D, Derived>() && (Cardinality >= 0 ||
-                    SizedIteratorRange<range_iterator_t<D>, range_sentinel_t<D>>()))>
+                CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality >= 0)>
 #endif
             constexpr range_size_t<D> size() const
             {
-                return Cardinality >= 0 ?
-                    (range_size_t<D>)Cardinality :
-                    iter_size(derived().begin(), derived().end());
+                return (range_size_t<D>)Cardinality;
+            }
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>::value && Cardinality < 0 &&
+                    SizedIteratorRange<range_iterator_t<const D>,
+                        range_sentinel_t<const D>>::value)>
+#else
+            template<typename D = Derived,
+                CONCEPT_REQUIRES_(Same<D, Derived>() && Cardinality < 0 &&
+                    SizedIteratorRange<range_iterator_t<const D>,
+                        range_sentinel_t<const D>>())>
+#endif
+            constexpr range_size_t<D> size() const
+            {
+                return iter_size(derived().begin(), derived().end());
             }
             /// Access the first element in a range:
             template<typename D = Derived,
@@ -343,7 +354,8 @@ namespace ranges
                 sout << '[' << *it;
                 while(++it != e)
                     sout << ',' << *it;
-                return sout << ']';
+                sout << ']';
+                return sout;
             }
             /// \overload
             template<bool B = true, typename Stream = meta::if_c<B, std::ostream>,
@@ -357,17 +369,22 @@ namespace ranges
                 auto it = ranges::begin(rng);
                 auto const e = ranges::end(rng);
                 if(it == e)
-                    return sout << "[]";
+                {
+                    sout << "[]";
+                    return sout;
+                }
                 sout << '[' << *it;
                 while(++it != e)
                     sout << ',' << *it;
-                return sout << ']';
+                sout << ']';
+                return sout;
             }
             /// \overload
             template<bool B = true, typename Stream = meta::if_c<B, std::ostream>>
             friend Stream &operator<<(Stream &sout, Derived &&rng)
             {
-                return sout << rng;
+                sout << rng;
+                return sout;
             }
         };
         /// @}

--- a/perf/sort_patterns.cpp
+++ b/perf/sort_patterns.cpp
@@ -150,20 +150,18 @@ namespace
     benchmark(Computation &&c, Sizes &&sizes, double target_deviation = 0.25,
               std::size_t max_iters = 100, std::size_t min_iters = 5) {
 
+      RANGES_ASSERT(0 < min_iters && min_iters <= max_iters);
       RANGES_FOR(auto size, sizes) {
         std::vector<duration_t> durations;
-        duration_t deviation;
-        duration_t mean_duration;
-        std::size_t iter;
+        duration_t deviation{};
+        duration_t mean_duration{};
+        std::size_t iter = 0;
 
-        for (iter = 0; iter < max_iters; ++iter) {
+        while (iter < max_iters) {
           c.init(size);
           durations.emplace_back(duration(c));
           mean_duration = compute_mean(durations);
-          if (++iter == max_iters) {
-            break;
-          }
-          if (iter >= min_iters) {
+          if (++iter >= min_iters) {
             deviation = compute_stddev(durations);
             if (deviation < target_deviation * mean_duration)
               break;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,3 +30,6 @@ add_test(test.to_container, to_container)
 
 add_executable(getlines getlines.cpp)
 add_test(test.getlines, getlines)
+
+add_executable(istream_range istream_range.cpp)
+add_test(test.istream_range, istream_range)

--- a/test/algorithm/copy_backward.cpp
+++ b/test/algorithm/copy_backward.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <range/v3/core.hpp>
 #include <range/v3/algorithm/copy_backward.hpp>
-#include <range/v3/view/delimit.hpp>
 #include "../simple_test.hpp"
 
 int main()

--- a/test/algorithm/sort.cpp
+++ b/test/algorithm/sort.cpp
@@ -193,7 +193,7 @@ struct Int
 {
     using difference_type = int;
     int i_;
-    Int(int i = 0) : i_(0) {}
+    Int(int i = 0) : i_(i) {}
     Int(Int && that) : i_(that.i_) { that.i_ = 0; }
     Int(Int const &) = delete;
     Int & operator=(Int && that)

--- a/test/istream_range.cpp
+++ b/test/istream_range.cpp
@@ -1,0 +1,33 @@
+#include <range/v3/istream_range.hpp>
+#include <range/v3/range.hpp>
+#include <sstream>
+#include "simple_test.hpp"
+#include "test_utils.hpp"
+
+struct moveonly
+{
+    char c;
+
+    moveonly() = default;
+    moveonly(moveonly &&) = default;
+    moveonly& operator=(moveonly &&) & = default;
+
+    operator char() const
+    {
+        return c;
+    }
+    friend std::istream &operator>>(std::istream &is, moveonly &m)
+    {
+        is.get(m.c);
+        return is;
+    }
+};
+
+int main()
+{
+    static const char test[] = "abcd3210";
+    std::istringstream ss{test};
+    ::check_equal(ranges::istream<moveonly>(ss),
+                  ranges::make_range(test, test + sizeof(test) - 1));
+    return ::test_result();
+}

--- a/test/test_iterators.hpp
+++ b/test/test_iterators.hpp
@@ -415,36 +415,21 @@ struct sentinel_type<I<It>, Sized>
 
 namespace ranges
 {
-    template<typename I0, bool S, typename I1>
-    struct common_type<sentinel<I0, S>, I1>
+    template<typename I0, bool B, typename I1>
+    struct common_type<sentinel<I0, B>, I1>
     {
-        using type = common_iterator<I1, sentinel<I0, S>>;
+        using type = common_iterator<I1, sentinel<I0, B>>;
     };
-    template<typename I0, typename I1, bool S>
-    struct common_type<I0, sentinel<I1, S>>
+    template<typename I0, typename I1, bool B>
+    struct common_type<I0, sentinel<I1, B>>
     {
-        using type = common_iterator<I0, sentinel<I1, S>>;
+        using type = common_iterator<I0, sentinel<I1, B>>;
     };
     template<typename I, bool B>
     struct common_type<sentinel<I, B>, sentinel<I, B>>
     {
-        using type = sentinel<I>;
-    };
-    template<typename I0, bool S, typename I1, typename TQual, typename UQual>
-    struct basic_common_reference<sentinel<I0, S>, I1, TQual, UQual>
-    {
-        using type = common_iterator<I1, sentinel<I0, S>>;
-    };
-    template<typename I0, typename I1, bool S, typename TQual, typename UQual>
-    struct basic_common_reference<I0, sentinel<I1, S>, TQual, UQual>
-    {
-        using type = common_iterator<I0, sentinel<I1, S>>;
-    };
-    template<typename I, bool B, typename TQual, typename UQual>
-    struct basic_common_reference<sentinel<I, B>, sentinel<I, B>, TQual, UQual>
-    {
-        using type = sentinel<I>;
+        using type = sentinel<I, B>;
     };
 }
 
-#endif  // ITERATORS_H
+#endif  // RANGES_TEST_ITERATORS_HPP

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -11,6 +11,9 @@ add_test(test.utility.common_type utility.common_type)
 add_executable(utility.functional functional.cpp)
 add_test(test.utility.functional utility.functional)
 
+add_executable(utility.iterator iterator.cpp)
+add_test(test.utility.iterator utility.iterator)
+
 add_executable(utility.reverse_iterator reverse_iterator.cpp)
 add_test(test.utility.reverse_iterator utility.reverse_iterator)
 

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -9,8 +9,10 @@
 //
 // Project home: https://github.com/ericniebler/range-v3
 
-#include <list>
-#include <range/v3/core.hpp>
+#include <cstring>
+#include <tuple>
+#include <range/v3/utility/basic_iterator.hpp>
+#include <range/v3/utility/common_tuple.hpp>
 #include "../simple_test.hpp"
 #include "../test_utils.hpp"
 
@@ -37,7 +39,7 @@ namespace test_weak_input
 #endif
         cursor(cursor<J> that) : it_(std::move(that.it_)) {}
 
-        auto current() const -> decltype(*it_) { return *it_; }
+        auto get() const -> decltype(*it_) { return *it_; }
         void next() { ++it_; }
     };
 
@@ -86,7 +88,7 @@ namespace test_random_access
 #endif
         cursor(cursor<J> that) : it_(std::move(that.it_)) {}
 
-        auto current() const -> decltype(*it_) { return *it_; }
+        auto get() const -> decltype(*it_) { return *it_; }
         bool equal(cursor<I> const &that) const  { return that.it_ == it_; }
         void next() { ++it_; }
         void prev() { --it_; }
@@ -134,6 +136,243 @@ namespace test_random_access
     }
 }
 
+namespace test_weak_output
+{
+    template<typename I>
+    struct cursor
+    {
+    private:
+        friend ranges::range_access;
+        I it_;
+        void set(ranges::iterator_value_t<I> v) const { *it_ = v; }
+        void next() { ++it_; }
+    public:
+        struct mixin : ranges::basic_mixin<cursor>
+        {
+            mixin() = default;
+            mixin(cursor c) : ranges::basic_mixin<cursor>(c) {}
+            mixin(I i) : ranges::basic_mixin<cursor>(cursor{i}) {}
+        };
+        cursor() = default;
+        explicit cursor(I i) : it_(i) {}
+    };
+
+    CONCEPT_ASSERT(ranges::detail::WeakOutputCursor<cursor<char*>, char>());
+
+    template<class I>
+    using iterator = ranges::basic_iterator<cursor<I>>;
+
+    CONCEPT_ASSERT(ranges::WeakOutputIterator<iterator<char*>, char>());
+
+    void test()
+    {
+        char buf[10];
+        iterator<char*> i(buf);
+        *i = 'h';
+        ++i;
+        *i = 'e';
+        ++i;
+        *i = 'l';
+        ++i;
+        *i = 'l';
+        ++i;
+        *i = 'o';
+        ++i;
+        *i = '\0';
+        CHECK(0 == std::strcmp(buf, "hello"));
+    }
+}
+
+namespace test_output
+{
+    template<typename I>
+    struct cursor
+    {
+        I it_;
+        struct mixin : ranges::basic_mixin<cursor>
+        {
+            mixin() = default;
+            mixin(cursor c) : ranges::basic_mixin<cursor>(c) {}
+            mixin(I i) : ranges::basic_mixin<cursor>(cursor{i}) {}
+        };
+        cursor() = default;
+        explicit cursor(I i) : it_(i) {}
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>::value)>
+#else
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
+#endif
+        cursor(cursor<J> that) : it_(std::move(that.it_)) {}
+
+        using value_type = ranges::iterator_value_t<I>;
+        value_type get() const { return *it_; }
+        void set(value_type v) const { *it_ = v; }
+        void next() { ++it_; }
+        bool equal(cursor const &that) const { return it_ == that.it_; }
+    };
+
+    CONCEPT_ASSERT(ranges::detail::OutputCursor<cursor<char*>, char>());
+    CONCEPT_ASSERT(ranges::detail::ForwardCursor<cursor<char*>>());
+
+    template<class I>
+    using iterator = ranges::basic_iterator<cursor<I>>;
+
+    CONCEPT_ASSERT(ranges::OutputIterator<iterator<char*>, char>());
+    CONCEPT_ASSERT(ranges::ForwardIterator<iterator<char*>>());
+
+    void test()
+    {
+        char buf[10];
+        iterator<char*> i(buf);
+        *i = 'h';
+        CHECK(*i == 'h');
+        CHECK(*i == *i);
+        ++i;
+        *i = 'e';
+        CHECK('e' == *i);
+        ++i;
+        *i = 'l';
+        ++i;
+        *i = 'l';
+        ++i;
+        *i = 'o';
+        ++i;
+        *i = '\0';
+        CHECK(0 == std::strcmp(buf, "hello"));
+        CHECK(i == iterator<char*>{buf+5});
+        ++i;
+        CHECK(i != iterator<char*>{buf+5});
+        CHECK(i == iterator<char*>{buf+6});
+    }
+}
+
+namespace test_move_only
+{
+    struct MoveOnly
+    {
+        MoveOnly() = default;
+        MoveOnly(MoveOnly &&) = default;
+        MoveOnly(MoveOnly const &) = delete;
+        MoveOnly &operator=(MoveOnly &&) = default;
+        MoveOnly &operator=(MoveOnly const &) = delete;
+    };
+
+    template<typename I>
+    struct zip1_cursor
+    {
+        I it_;
+        struct mixin : ranges::basic_mixin<zip1_cursor>
+        {
+            mixin() = default;
+            mixin(zip1_cursor c) : ranges::basic_mixin<zip1_cursor>(c) {}
+            mixin(I i) : ranges::basic_mixin<zip1_cursor>(zip1_cursor{i}) {}
+        };
+        zip1_cursor() = default;
+        explicit zip1_cursor(I i) : it_(i) {}
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>::value)>
+#else
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
+#endif
+        zip1_cursor(zip1_cursor<J> that) : it_(std::move(that.it_)) {}
+
+        using value_type = std::tuple<ranges::iterator_value_t<I>>;
+        using reference = ranges::common_tuple<ranges::iterator_reference_t<I>>;
+        using rvalue_reference = ranges::common_tuple<ranges::iterator_rvalue_reference_t<I>>;
+        reference get() const { return reference{*it_}; }
+        rvalue_reference move() const { return rvalue_reference{ranges::iter_move(it_)}; }
+        void set(reference const &v) const { reference{*it_} = v; }
+        void set(value_type&& v) const { reference{*it_} = std::move(v); }
+        void next() { ++it_; }
+        bool equal(zip1_cursor const &that) const { return it_ == that.it_; }
+    };
+
+    CONCEPT_ASSERT(ranges::detail::OutputCursor<zip1_cursor<MoveOnly*>, std::tuple<MoveOnly>&&>());
+    CONCEPT_ASSERT(ranges::detail::ForwardCursor<zip1_cursor<MoveOnly*>>());
+
+    template<class I>
+    using iterator = ranges::basic_iterator<zip1_cursor<I>>;
+
+    CONCEPT_ASSERT(ranges::OutputIterator<iterator<MoveOnly*>, std::tuple<MoveOnly>&&>());
+    CONCEPT_ASSERT(ranges::ForwardIterator<iterator<MoveOnly*>>());
+
+    void test()
+    {
+        MoveOnly buf[10] = {};
+        iterator<MoveOnly*> i(buf);
+        *i = std::tuple<MoveOnly>{};
+        ranges::common_tuple<MoveOnly&> x = *i; (void)x;
+        std::tuple<MoveOnly> v = ranges::iter_move(i);
+        *i = std::move(v);
+    }
+}
+
+namespace test_forward_sized
+{
+    template<typename I>
+    struct cursor
+    {
+        I it_;
+        struct mixin : ranges::basic_mixin<cursor>
+        {
+            mixin() = default;
+            mixin(cursor c) : ranges::basic_mixin<cursor>(c) {}
+            mixin(I i) : ranges::basic_mixin<cursor>(cursor{i}) {}
+        };
+        cursor() = default;
+        explicit cursor(I i) : it_(i) {}
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>::value)>
+#else
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
+#endif
+        cursor(cursor<J> that) : it_(std::move(that.it_)) {}
+
+        auto get() const -> decltype(*it_) { return *it_; }
+        bool equal(cursor<I> const &that) const  { return that.it_ == it_; }
+        void next() { ++it_; }
+        ranges::iterator_difference_t<I> distance_to(cursor<I> const &that) const {
+            return that.it_ - it_;
+        }
+    };
+
+    CONCEPT_ASSERT(ranges::detail::SizedCursor<cursor<char*>>());
+    CONCEPT_ASSERT(ranges::detail::ForwardCursor<cursor<char*>>());
+
+    template<class I>
+    using iterator = ranges::basic_iterator<cursor<I>>;
+
+    static_assert(
+        std::is_same<
+            iterator<char*>::iterator_category,
+            ranges::forward_iterator_tag>::value,
+        "");
+
+    void test()
+    {
+        using namespace ranges;
+
+        iterator<char*> a(nullptr);
+        iterator<char const *> b(nullptr);
+        iterator<char const *> c(a);
+
+        b = a;
+        bool d = a == b;
+        d = (a != b);
+
+        detail::ignore_unused(
+            d,
+            a < b,
+            a <= b,
+            a > b,
+            a >= b,
+            (a-b),
+            (b-a),
+            (a-a),
+            (b-b));
+    }
+}
+
 int main()
 {
     using namespace ranges;
@@ -141,6 +380,10 @@ int main()
 
     ::test_weak_input::test();
     ::test_random_access::test();
+    ::test_weak_output::test();
+    ::test_output::test();
+    ::test_move_only::test();
+    ::test_forward_sized::test();
 
     return ::test_result();
 }

--- a/test/utility/basic_iterator.cpp
+++ b/test/utility/basic_iterator.cpp
@@ -16,65 +16,131 @@
 
 #include <range/v3/utility/counted_iterator.hpp>
 
-template<typename I>
-struct cursor
+namespace test_weak_input
 {
-    I it_;
-    struct mixin : ranges::basic_mixin<cursor>
+    template<typename I>
+    struct cursor
     {
-        mixin() = default;
-        mixin(cursor c) : ranges::basic_mixin<cursor>(c) {}
-        mixin(I i) : ranges::basic_mixin<cursor>(cursor{i}) {}
-    };
-    cursor() = default;
-    explicit cursor(I i) : it_(i) {}
+        I it_;
+        struct mixin : ranges::basic_mixin<cursor>
+        {
+            mixin() = default;
+            mixin(cursor c) : ranges::basic_mixin<cursor>(c) {}
+            mixin(I i) : ranges::basic_mixin<cursor>(cursor{i}) {}
+        };
+        cursor() = default;
+        explicit cursor(I i) : it_(i) {}
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-    template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>::value)>
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>::value)>
 #else
-    template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
 #endif
-    cursor(cursor<J> that) : it_(std::move(that.it_)) {}
+        cursor(cursor<J> that) : it_(std::move(that.it_)) {}
 
-    auto current() const -> decltype(*it_) { return *it_; }
-    bool equal(cursor<I> const &that) const  { return that.it_ == it_; }
-    void next() { ++it_; }
-    void prev() { --it_; }
-    void advance(ranges::iterator_difference_t<I> n) {
-        it_ += n;
+        auto current() const -> decltype(*it_) { return *it_; }
+        void next() { ++it_; }
+    };
+
+    CONCEPT_ASSERT(ranges::detail::WeakInputCursor<cursor<char*>>());
+
+    template<class I>
+    using iterator = ranges::basic_iterator<cursor<I>>;
+
+    static_assert(
+        std::is_same<
+            iterator<char*>::iterator_category,
+            ranges::weak_input_iterator_tag>::value,
+        "");
+
+    void test()
+    {
+        using namespace ranges;
+        using I = iterator<char const *>;
+
+        static const char sz[] = "hello world";
+        I i{sz};
+        CHECK(*i == 'h');
+        ++i;
+        CHECK(*i == 'e');
     }
-    ranges::iterator_difference_t<I> distance_to(cursor<I> const &that) const {
-        return that.it_ - it_;
+}
+
+namespace test_random_access
+{
+    template<typename I>
+    struct cursor
+    {
+        I it_;
+        struct mixin : ranges::basic_mixin<cursor>
+        {
+            mixin() = default;
+            mixin(cursor c) : ranges::basic_mixin<cursor>(c) {}
+            mixin(I i) : ranges::basic_mixin<cursor>(cursor{i}) {}
+        };
+        cursor() = default;
+        explicit cursor(I i) : it_(i) {}
+#ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>::value)>
+#else
+        template<class J, CONCEPT_REQUIRES_(ranges::ConvertibleTo<J, I>())>
+#endif
+        cursor(cursor<J> that) : it_(std::move(that.it_)) {}
+
+        auto current() const -> decltype(*it_) { return *it_; }
+        bool equal(cursor<I> const &that) const  { return that.it_ == it_; }
+        void next() { ++it_; }
+        void prev() { --it_; }
+        void advance(ranges::iterator_difference_t<I> n) {
+            it_ += n;
+        }
+        ranges::iterator_difference_t<I> distance_to(cursor<I> const &that) const {
+            return that.it_ - it_;
+        }
+    };
+
+    CONCEPT_ASSERT(ranges::detail::RandomAccessCursor<cursor<char*>>());
+
+    template<class I>
+    using iterator = ranges::basic_iterator<cursor<I>>;
+
+    static_assert(
+        std::is_same<
+            iterator<char*>::iterator_category,
+            ranges::random_access_iterator_tag>::value,
+        "");
+
+    void test()
+    {
+        using namespace ranges;
+
+        iterator<char*> a(nullptr);
+        iterator<char const *> b(nullptr);
+        iterator<char const *> c(a);
+
+        b = a;
+        bool d = a == b;
+        d = (a != b);
+
+        detail::ignore_unused(
+            d,
+            a < b,
+            a <= b,
+            a > b,
+            a >= b,
+            (a-b),
+            (b-a),
+            (a-a),
+            (b-b));
     }
-};
-
-CONCEPT_ASSERT(ranges::detail::RandomAccessCursor<cursor<char*>>());
-
-template<class I>
-using iterator = ranges::basic_iterator<cursor<I>>;
+}
 
 int main()
 {
     using namespace ranges;
     std::cout << "\nTesting basic_iterator\n";
 
-    iterator<char*> a(nullptr);
-    iterator<char const *> b(nullptr);
-    iterator<char const *> c(a);
-
-    b = a;
-    bool d = a == b;
-    d = (a != b);
-
-    detail::ignore_unused(
-        d,
-        a < b,
-        a <= b,
-        a > b,
-        a >= b,
-        (a-b),
-        (b-a),
-        (a-a),
-        (b-b));
+    ::test_weak_input::test();
+    ::test_random_access::test();
 
     return ::test_result();
 }

--- a/test/utility/functional.cpp
+++ b/test/utility/functional.cpp
@@ -10,7 +10,16 @@
 // Project home: https://github.com/ericniebler/range-v3
 
 #include <range/v3/utility/functional.hpp>
+#include <range/v3/view/filter.hpp>
 #include "../simple_test.hpp"
+#include "../test_utils.hpp"
+
+struct Integer
+{
+    int i;
+    operator int() const { return i; }
+    bool odd() const { return (i % 2) != 0; }
+};
 
 int main()
 {
@@ -50,5 +59,13 @@ int main()
     CHECK(&ri3_ == &ci);
 
     detail::ignore_unused(ri_, ri1_, ri2_, ri3_, j);
+
+    {
+      // Check that not_ works with callables
+      Integer some_ints[] = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}};
+      ::check_equal(some_ints | view::filter(ranges::not_(&Integer::odd)),
+                    {0,2,4,6});
+    }
+
     return test_result();
 }

--- a/test/utility/iterator.cpp
+++ b/test/utility/iterator.cpp
@@ -1,0 +1,33 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <vector>
+#include <range/v3/utility/iterator.hpp>
+#include <range/v3/algorithm/copy.hpp>
+#include "../simple_test.hpp"
+#include "../test_utils.hpp"
+
+using namespace ranges;
+
+void test_insert_iterator()
+{
+    CONCEPT_ASSERT(WeakOutputIterator<insert_iterator<std::vector<int>>, int&&>());
+    std::vector<int> vi{5,6,7,8};
+    copy({1,2,3,4}, inserter(vi, vi.begin()+2));
+    ::check_equal(vi, {5,6,1,2,3,4,7,8});
+}
+
+int main()
+{
+    test_insert_iterator();
+
+    return ::test_result();
+}

--- a/test/view/iota.cpp
+++ b/test/view/iota.cpp
@@ -30,6 +30,24 @@ struct Int
     bool operator!=(Int j) const { return i != j.i; }
 };
 
+template <typename Integral>
+void test_iota_minus() {
+  using namespace ranges;
+  using D = detail::iota_difference_t<Integral>;
+  using I = Integral;
+  Integral max = std::numeric_limits<Integral>::max();
+
+  CHECK(detail::iota_minus(I(0), I(0)) == D(0));
+  CHECK(detail::iota_minus(I(0), I(1)) == D(-1));
+  CHECK(detail::iota_minus(I(1), I(0)) ==  D(1));
+  CHECK(detail::iota_minus(I(1), I(1)) == D(0));
+
+  CHECK(detail::iota_minus(I(max - I(1)), I(max - I(1))) == D(0));
+  CHECK(detail::iota_minus(I(max - I(1)), I(max)) == D(-1));
+  CHECK(detail::iota_minus(I(max), I(max - I(1))) == D(1));
+  CHECK(detail::iota_minus(I(max), I(max)) == D(0));
+}
+
 int main()
 {
     using namespace ranges;
@@ -75,6 +93,18 @@ int main()
         auto ints = view::closed_iota(Int{0}, Int{10});
         ::check_equal(ints, {Int{0},Int{1},Int{2},Int{3},Int{4},Int{5},Int{6},Int{7},Int{8},Int{9},Int{10}});
         models_not<concepts::BoundedView>(ints);
+    }
+
+    {  // iota minus tests
+      test_iota_minus<int8_t>();
+      test_iota_minus<int16_t>();
+      test_iota_minus<int32_t>();
+      test_iota_minus<int64_t>();
+
+      test_iota_minus<uint8_t>();
+      test_iota_minus<uint16_t>();
+      test_iota_minus<uint32_t>();
+      test_iota_minus<uint64_t>();
     }
 
     return ::test_result();

--- a/test/view/partial_sum.cpp
+++ b/test/view/partial_sum.cpp
@@ -32,7 +32,7 @@ int main()
 
     int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    auto && rng = rgi | view::partial_sum(std::plus<int>());
+    auto && rng = rgi | view::partial_sum();
     has_type<int &>(*begin(rgi));
     has_type<int>(*begin(rng));
     models<concepts::SizedView>(rng);

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -51,7 +51,7 @@ private:
         {
             ++it;
         }
-        ranges::range_reference_t<BidiRange> current(base_iterator_t it) const
+        ranges::range_reference_t<BidiRange> get(base_iterator_t it) const
         {
             return *ranges::prev(it);
         }
@@ -65,9 +65,9 @@ private:
             it -= n;
         }
 #ifdef RANGES_WORKAROUND_MSVC_SFINAE_CONSTEXPR
-        CONCEPT_REQUIRES(ranges::RandomAccessRange<BidiRange>::value)
+        CONCEPT_REQUIRES(ranges::SizedIteratorRange<base_iterator_t, base_iterator_t>::value)
 #else
-        CONCEPT_REQUIRES(ranges::RandomAccessRange<BidiRange>())
+        CONCEPT_REQUIRES(ranges::SizedIteratorRange<base_iterator_t, base_iterator_t>())
 #endif
         ranges::range_difference_t<BidiRange>
         distance_to(base_iterator_t const &here, base_iterator_t const &there)

--- a/test/view_adaptor.cpp
+++ b/test/view_adaptor.cpp
@@ -92,7 +92,7 @@ struct my_delimited_range
         my_delimited_range,
         ranges::delimit_view<ranges::istream_range<int>, int>>
 {
-    using view_adaptor_t::view_adaptor_t;
+    using my_delimited_range::view_adaptor::view_adaptor;
 };
 
 int main()

--- a/test/view_facade.cpp
+++ b/test/view_facade.cpp
@@ -29,7 +29,7 @@ private:
         cursor(std::vector<int>::const_iterator it)
           : iter(it)
         {}
-        int const & current() const
+        int const & get() const
         {
             return *iter;
         }


### PR DESCRIPTION
Also:

* Eradicate the `view_adaptor_t` alias, use of which is often ill-formed in the codebase but bug-friendly with gcc and clang. (This happened in May 2016 upstream.)

* Workaround that VS2017 again thinks that pseudo-destructor syntax is valid for array types. The fix for this was moved under /permissive-, but this library should work independently of the /permissive- option.
